### PR TITLE
Use base 10 for month arithmetic

### DIFF
--- a/contrib/manyclangs-build-month
+++ b/contrib/manyclangs-build-month
@@ -17,7 +17,7 @@ list_month() {
     YEAR="$2"
 
     ((NEXT_YEAR=YEAR))
-    ((NEXT_MONTH=MONTH+1))
+    ((NEXT_MONTH=10#$MONTH+1))
     if [ $NEXT_MONTH -eq 13 ]; then
         ((NEXT_YEAR=NEXT_YEAR+1))
         ((NEXT_MONTH=1))


### PR DESCRIPTION
When passed MM, manyclangs-build-month would fail as it would try to
interpret 09 as on octal number. The other months seem fine to me,
because 01-08 are the same in decimal and octal, and 10,11,12 don't have
a leading zero. I don't see a problem with any other arithmetic taking
place.

Fixes #2.

Signed-off-by: Peter Waller <peter.waller@arm.com>