### PR TITLE
Remove head fields from Repository

### DIFF
--- a/src/bin/elfshaker/extract.rs
+++ b/src/bin/elfshaker/extract.rs
@@ -33,15 +33,20 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
     let mut repo = open_repo_from_cwd()?;
     let new_head = repo.find_snapshot(snapshot)?;
 
-    if repo.head().as_ref() == Some(&new_head) && !is_reset {
-        // The specified snapshot is already extracted and --reset is not specified,
-        // so this is a no-op.
-        warn!(
-            "HEAD is already at {} and --reset is not specified. Exiting early...",
-            repo.head().as_ref().unwrap()
-        );
-        return Ok(());
-    }
+    match repo.read_head()? {
+        (Some(h), _) if h == new_head && !is_reset => {
+            // The specified snapshot is already extracted and --reset is not specified,
+            // so this is a no-op.
+            warn!(
+                "HEAD is already at {} and --reset is not specified. Exiting early...",
+                h,
+            );
+            return Ok(());
+
+        },
+        _ => {},
+    };
+
 
     let mut opts = ExtractOptions::default();
     opts.set_verify(is_verify);

--- a/src/bin/elfshaker/pack.rs
+++ b/src/bin/elfshaker/pack.rs
@@ -126,7 +126,7 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
         &reporter,
     )?;
 
-    if let Some(head) = repo.head() {
+    if let (Some(head), _) = repo.read_head()? {
         if indexes.iter().any(|pack_id| head.pack() == pack_id) {
             info!("Updating HEAD to point to the newly-created pack...");
             // The current HEAD was referencing a snapshot an index which has


### PR DESCRIPTION
They are very cheap to calculate and they are consulted rarely, so there is not
much point caching them.

This is a lower priority change, and draft, because I removed some tests which
may be significant. I think for now we should test these from check.sh, if they are worth testing.

- [ ] TODO: Analyse remove tests and make sure I've not dropped something important.

Signed-off-by: Peter Waller <peter.waller@arm.com>
