### PR TITLE
Potential fix for #7

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -12,6 +12,7 @@ use std::{
     io::{self, Read, Write},
     path::Path,
 };
+// use super::utils::open_file;
 use zstd::stream::raw::CParameter;
 use zstd::Encoder;
 
@@ -72,7 +73,7 @@ where
     for (i, obj) in object_readers.enumerate() {
         // TODO(peterwaller-arm): Verify object checksums here, abort on mismatch.
         let mut obj = obj?;
-        // let mut file = File::open(&obj)?;
+        // let mut file = open_file(&obj)?;
         let bytes = io::copy(&mut obj, &mut encoder)?;
         processed_bytes += bytes;
         reporter.checkpoint(i, Some(n_objects - i));

--- a/src/bin/elfshaker/show.rs
+++ b/src/bin/elfshaker/show.rs
@@ -5,7 +5,7 @@ use clap::{App, Arg, ArgMatches};
 use rand::RngCore;
 use std::{collections::HashMap, error::Error};
 
-use super::utils::open_repo_from_cwd;
+use super::utils::{open_repo_from_cwd, open_file};
 use elfshaker::repo::ExtractOptions;
 
 pub(crate) const SUBCOMMAND: &str = "show";
@@ -60,7 +60,7 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
         // Dump the contents of all entries to stdout.
         for e in &selected_entries {
             let path = temp_dir.join(&e.path);
-            std::io::copy(&mut std::fs::File::open(path)?, &mut std::io::stdout())?;
+            std::io::copy(&mut open_file(path)?, &mut std::io::stdout())?;
         }
         Ok(())
     };

--- a/src/bin/elfshaker/utils.rs
+++ b/src/bin/elfshaker/utils.rs
@@ -128,12 +128,3 @@ pub fn create_percentage_print_reporter(message: &str, step: u32) -> ProgressRep
         }
     })
 }
-
-/// Opens a file and gives a useful error if it fails.
-/// If possible, use this instead of File::open if you don't handle errors yourself.
-pub fn open_file(path: &Path) -> File {
-    match File::open(&path) {
-        Err(why) => panic!("couldn't open {}: {}", path.display(), why),
-        Ok(file) => file
-    }
-}

--- a/src/bin/elfshaker/utils.rs
+++ b/src/bin/elfshaker/utils.rs
@@ -6,6 +6,7 @@ use elfshaker::progress::ProgressReporter;
 use elfshaker::repo::{Error as RepoError, Repository};
 use log::info;
 use std::io::Write;
+use std::fs::File;
 use std::sync::{
     atomic::{AtomicIsize, Ordering},
     Arc,
@@ -126,4 +127,13 @@ pub fn create_percentage_print_reporter(message: &str, step: u32) -> ProgressRep
             std::io::stdout().flush().unwrap();
         }
     })
+}
+
+/// Opens a file and gives a useful error if it fails.
+/// If possible, use this instead of File::open if you don't handle errors yourself.
+pub fn open_file(path: &Path) -> File {
+    match File::open(&path) {
+        Err(why) => panic!("couldn't open {}: {}", path.display(), why),
+        Ok(file) => file
+    }
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,6 +1,6 @@
 /// Opens a file and returns a useful error if it fails
 /// If possible use this instead of File::open for usability purposes
-pub fn open_file(path: &std::path::Path) -> std::io::Result<std::fs::File> {
+pub fn open_file<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<std::fs::File> {
     match std::fs::File::open(&path) {
         Err(why) => Err(std::io::Error::new(why.kind(), format!("couldn't open {}", path.display()))),
         Ok(file) => Ok(file),

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,0 +1,8 @@
+/// Opens a file and returns a useful error if it fails
+/// If possible use this instead of File::open for usability purposes
+pub fn open_file(path: &std::path::Path) -> std::io::Result<std::fs::File> {
+    match std::fs::File::open(&path) {
+        Err(why) => Err(std::io::Error::new(why.kind(), format!("couldn't open {}", path.display()))),
+        Ok(file) => Ok(file),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod atomicfile;
 pub mod batch;
 pub mod entrypool;
+pub mod fs;
 pub mod log;
 pub mod packidx;
 pub mod progress;

--- a/src/packidx.rs
+++ b/src/packidx.rs
@@ -4,6 +4,7 @@
 //! Contains types and function for parsing `.pack.idx` files created by
 //! elfshaker.
 use crate::entrypool::{EntryPool, Handle};
+use crate::fs::open_file;
 use crate::repo::partition_by_u64;
 
 use serde::de::{SeqAccess, Visitor};
@@ -17,7 +18,6 @@ use std::io::{BufReader, BufWriter, Read, Write};
 use std::iter::FromIterator;
 use std::ops::ControlFlow;
 use std::path::Path;
-use super::utils::open_file;
 
 /// Error type used in the packidx module.
 #[derive(Debug)]

--- a/src/packidx.rs
+++ b/src/packidx.rs
@@ -17,6 +17,7 @@ use std::io::{BufReader, BufWriter, Read, Write};
 use std::iter::FromIterator;
 use std::ops::ControlFlow;
 use std::path::Path;
+use super::utils::open_file;
 
 /// Error type used in the packidx module.
 #[derive(Debug)]
@@ -441,7 +442,7 @@ impl PackIndex {
 
 impl PackIndex {
     pub fn load<P: AsRef<Path>>(p: P) -> Result<PackIndex, PackError> {
-        let rd = File::open(p.as_ref())?;
+        let rd = open_file(p.as_ref())?;
         let mut rd = BufReader::new(rd);
         Self::read_magic(&mut rd)?;
 

--- a/src/repo/pack.rs
+++ b/src/repo/pack.rs
@@ -24,9 +24,9 @@ use super::constants::{
 };
 use super::error::Error;
 use super::repository::Repository;
-use super::{algo::run_in_parallel, constants::DOT_PACK_INDEX_EXTENSION, utils::open_file};
+use super::{algo::run_in_parallel, constants::DOT_PACK_INDEX_EXTENSION};
 use crate::packidx::{FileEntry, ObjectChecksum, PackError, PackIndex};
-use crate::{log::measure_ok, packidx::ObjectMetadata};
+use crate::{fs::open_file, log::measure_ok, packidx::ObjectMetadata};
 
 /// Pack and snapshots IDs can contain latin letter, digits or the following characters.
 const EXTRA_ID_CHARS: &[char] = &['-', '_', '/'];

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -23,11 +23,11 @@ use super::constants::REPO_DIR;
 use super::error::Error;
 use super::fs::{create_temp_path, ensure_dir, get_last_modified, write_file_atomic};
 use super::pack::{write_skippable_frame, Pack, PackFrame, PackHeader, PackId, SnapshotId};
-use super::utils::open_file;
 use crate::packidx::{FileEntry, ObjectChecksum, PackError, PackIndex};
 use crate::progress::ProgressReporter;
 use crate::{
     batch,
+    fs::open_file,
     packidx::{ObjectMetadata, LOOSE_OBJECT_OFFSET},
 };
 use crypto::digest::Digest;
@@ -147,7 +147,7 @@ impl Repository {
     pub fn read_head(&self) -> Result<(Option<SnapshotId>, Option<SystemTime>), Error> {
         let path = self.path.join(&*Self::data_dir()).join(HEAD_FILE);
 
-        let (head, mtime) = match File::open(path) {
+        let (head, mtime) = match open_file(&path) {
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => (None, None),
             Err(e) => return Err(e.into()),
             Ok(mut file) => {

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -23,6 +23,7 @@ use super::constants::REPO_DIR;
 use super::error::Error;
 use super::fs::{create_temp_path, ensure_dir, get_last_modified, write_file_atomic};
 use super::pack::{write_skippable_frame, Pack, PackFrame, PackHeader, PackId, SnapshotId};
+use super::utils::open_file;
 use crate::packidx::{FileEntry, ObjectChecksum, PackError, PackIndex};
 use crate::progress::ProgressReporter;
 use crate::{
@@ -549,7 +550,7 @@ impl Repository {
                 let object_readers = objects.iter().map(|&handle| {
                     // TODO: Method of obtaining readers from packs? Or we can
                     // just assume packs first get unpacked.
-                    Ok(Box::new(File::open(
+                    Ok(Box::new(open_file(
                         self.loose_object_path(index.handle_to_checksum(handle)),
                     )?))
                 });


### PR DESCRIPTION
I've added the open_file function in src/bin/elfshaker/utils.rs,
this calls File::open and gives a useful error if it fails. Is's
meant to be used in place of File::open unless there is proper
error handling.

I've also replaced most existing references to File::open with open_file.