### PR TITLE
Make I/O errors more informative

### DIFF
--- a/src/bin/elfshaker/show.rs
+++ b/src/bin/elfshaker/show.rs
@@ -6,6 +6,7 @@ use rand::RngCore;
 use std::{collections::HashMap, error::Error};
 
 use super::utils::open_repo_from_cwd;
+use elfshaker::repo::fs::open_file;
 use elfshaker::repo::ExtractOptions;
 
 pub(crate) const SUBCOMMAND: &str = "show";
@@ -60,7 +61,7 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
         // Dump the contents of all entries to stdout.
         for e in &selected_entries {
             let path = temp_dir.join(&e.path);
-            std::io::copy(&mut std::fs::File::open(path)?, &mut std::io::stdout())?;
+            std::io::copy(&mut open_file(path)?, &mut std::io::stdout())?;
         }
         Ok(())
     };

--- a/src/packidx.rs
+++ b/src/packidx.rs
@@ -4,14 +4,16 @@
 //! Contains types and function for parsing `.pack.idx` files created by
 //! elfshaker.
 use crate::entrypool::{EntryPool, Handle};
-use crate::repo::partition_by_u64;
+use crate::repo::{
+    fs::{create_file, open_file},
+    partition_by_u64,
+};
 
 use serde::de::{SeqAccess, Visitor};
 use serde::{ser::SerializeTuple, Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::{BTreeMap, HashSet};
 use std::ffi::OsString;
 use std::fmt;
-use std::fs::File;
 use std::hash::Hash;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::iter::FromIterator;
@@ -441,7 +443,7 @@ impl PackIndex {
 
 impl PackIndex {
     pub fn load<P: AsRef<Path>>(p: P) -> Result<PackIndex, PackError> {
-        let rd = File::open(p.as_ref())?;
+        let rd = open_file(p.as_ref())?;
         let mut rd = BufReader::new(rd);
         Self::read_magic(&mut rd)?;
 
@@ -450,7 +452,7 @@ impl PackIndex {
 
     pub fn save<P: AsRef<Path>>(&self, p: P) -> Result<(), PackError> {
         // TODO: Use AtomicCreateFile.
-        let wr = File::create(p.as_ref())?;
+        let wr = create_file(p.as_ref())?;
         let mut wr = BufWriter::new(wr);
         Self::write_magic(&mut wr)?;
 

--- a/src/repo/error.rs
+++ b/src/repo/error.rs
@@ -44,7 +44,11 @@ impl From<walkdir::Error> for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Self::IOError(ioerr) => ioerr.fmt(f),
+            Self::IOError(ioerr) => {
+                // Since the error message can be vague, we also print
+                // the internal error kind.
+                write!(f, "{} ({:?})", ioerr, ioerr.kind())
+            }
             Self::PackError(packerr) => packerr.fmt(f),
             Self::IdError(iderr) => iderr.fmt(f),
             Self::WalkDirError(wderr) => wderr.fmt(f),

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -5,7 +5,8 @@
 mod algo;
 mod constants;
 mod error;
-mod fs;
+#[doc(hidden)]
+pub mod fs;
 mod pack;
 mod repository;
 


### PR DESCRIPTION
I have wrapped all errors returned when
opening a file to include the associated file paths.

Closes #7.