### PR TITLE
Buildscript improvements

### DIFF
--- a/contrib/compdb2line/main.go
+++ b/contrib/compdb2line/main.go
@@ -195,7 +195,7 @@ checkfail() {
 # This script generates binaries.
 # Without arguments, it generates all of them.
 # Parallelism defaults to one linker per $(nproc) but can be
-# overridden by setting LINK_NPROC= to the desired number of
+# overridden by setting LINKSCRIPT_NPROC= to the desired number of
 # jobs to run in parallel.
 
 # link.sh --and-run <binary> <args...>
@@ -398,19 +398,19 @@ main() {
 		exit 128 # (unreachable)
 	fi
 
-	NPROC=${NPROC-$(nproc)}
+	LINKSCRIPT_NPROC=${LINKSCRIPT_NPROC-$(nproc)}
 
 	mkdir -p bin
 	if [ $# -eq 0 ]; then
 		# Link everything.
-		printf "%q\0" "${LINKSCRIPT_EXES[@]}" | xargs -0 -n1 -P${NPROC} bash "$THIS_SCRIPT"
+		printf "%q\0" "${LINKSCRIPT_EXES[@]}" | xargs -0 -n1 -P${LINKSCRIPT_NPROC} bash "$THIS_SCRIPT"
 	elif [ $# -eq 1 ]; then
 		# Link the one specified.
 		FUNCSAFENAME=$(echo "$1" | sed 's/[^A-Za-z0-9_+-]/_/g')
 		linkscript_check_exists "$FUNCSAFENAME"
 		"LINKSCRIPT_EXE_$FUNCSAFENAME"
 	else
-		printf "%q\0" "$@" | xargs -0 -n1 -P${NPROC} bash "$THIS_SCRIPT"
+		printf "%q\0" "$@" | xargs -0 -n1 -P${LINKSCRIPT_NPROC} bash "$THIS_SCRIPT"
 	fi
 }
 

--- a/contrib/compdb2line/main.go
+++ b/contrib/compdb2line/main.go
@@ -222,9 +222,9 @@ checkfail() {
 		arrayName := "LINKSCRIPT_A_" + arBaseName
 		arToBashObjArray[ar] = arrayName
 		bw.WriteString(arrayName)
-		bw.WriteString("=( ")
+		bw.WriteString("=( -Wl,--start-lib ")
 		bw.WriteString(braceContract(cdb.ArToObjs[ar]))
-		bw.WriteString(" )\n")
+		bw.WriteString(" -Wl,--end-lib )\n")
 	}
 
 	var exeBases []string
@@ -259,7 +259,7 @@ checkfail() {
 			}
 		}
 
-		bw.WriteString("maybe_dryrun filter_dupe_objs ")
+		bw.WriteString("maybe_dryrun ")
 
 		// Invocation.
 		switch first {
@@ -335,26 +335,6 @@ checkfail() {
 	bw.WriteRune('\n')
 
 	bw.WriteString(`
-# Run the given arguments, filtering .o files which are seen repeatedly (first one wins).
-filter_dupe_objs() {
-	args=()
-	declare -A seen_objs
-	for arg in "$@"
-	do
-		if [[ "${arg}" != "${arg%.o}" ]]
-		then
-			if ${seen_objs[$arg]-false}
-			then
-				# Avoid duplicating objects as input
-				continue
-			fi
-			seen_objs[$arg]=true
-		fi
-		args+=("$arg")
-	done
-
-	"${args[@]}"
-}
 
 maybe_dryrun() {
 	if ${LINKSCRIPT_DRY_RUN-false}

--- a/contrib/compdb2line/main.go
+++ b/contrib/compdb2line/main.go
@@ -303,7 +303,6 @@ checkfail() {
 		exeBases = append(exeBases, exeBase)
 		tgt := funcSafeName(exeBase)
 		src := funcSafeName(symlink.Src)
-		log.Println("Src: ", src, " Dest", tgt)
 		bw.WriteString("LINKSCRIPT_EXE_")
 		bw.WriteString(tgt)
 		bw.WriteString("() { ")
@@ -537,7 +536,6 @@ func parseCDB(pwd string) (cdb CompDB) {
 						if src == dst {
 							continue
 						}
-						log.Println("link: ", src, dst)
 						src = strings.TrimPrefix(src, "lib/")
 						cdb.Symlinks = append(cdb.Symlinks, Symlink{
 							src, dst,

--- a/contrib/manyclangs-build
+++ b/contrib/manyclangs-build
@@ -113,7 +113,7 @@ main() {
         # * https://github.com/elfshaker/elfshaker/issues/11
         # * https://bugs.llvm.org/show_bug.cgi?id=52360
         # ("__PRETTY_FUNCTION__ leaks absolute paths even with -fmacro-prefix-map").
-        cp build.ninja build.ninja.orig # backup, in case of failure.
+
         # shellcheck disable=SC2016
         awk_inplace -c -v "search=$ABS_BASE_PATH" -v "replace=$REL_BASE_PATH" '
             /^  INCLUDES = / { gsub(" -I"search, " -I"replace, $0); print; next }
@@ -127,7 +127,7 @@ main() {
         chmod +x link.sh
 
         # Avoid writing binaries out to disk, saves disk space when we're writing to tmpfs.
-        sed -Ei '/TARGET_FILE = bin\/(clang-ast-dump|(clang|llvm)-tblgen)/!s|TARGET_FILE = bin/.*|TARGET_FILE = /dev/null|' build.ninja
+        sed -E '/TARGET_FILE = bin\/(clang-ast-dump|(clang|llvm)-tblgen)/!s|TARGET_FILE = bin/.*|TARGET_FILE = /dev/null|' build.ninja > build.patched.ninja
     fi
 
     patch_clang_version "$COMMIT_SHA"
@@ -174,7 +174,7 @@ main() {
         CCACHE_NOCOMPRESS=1\
         CCACHE_SLOPPINESS=time_macros,include_file_ctime,include_file_mtime
         CCACHE_COMPILERCHECK=string:manyclangs-clang${BUILDER_CLANG_VERSION_SUFFIX} \
-        "${NINJA}" |& tee -a build.log
+        "${NINJA}" -f build.patched.ninja |& tee -a build.log
     then
         # On build success, the log is not very interesting, so delete it.
         rm build.log

--- a/contrib/manyclangs-build
+++ b/contrib/manyclangs-build
@@ -5,6 +5,10 @@
 [[ "$TRACE" ]] && set -x
 set -euo pipefail
 
+# Workaround for the fact that different programs can have different ideas about
+# what consitutes 'sorted' (particularly, affects 'comm' / 'jq' combination.)
+export LC_COLLATE=C
+
 BUILDER_CLANG_VERSION_SUFFIX=${BUILDER_CLANG_VERSION_SUFFIX--12}
 
 awk_inplace() {

--- a/contrib/manyclangs-build
+++ b/contrib/manyclangs-build
@@ -171,8 +171,8 @@ main() {
     # know no-one else will be modifying header files which may be newly checked
     # out.
     if time CCACHE_FILECLONE=1 \
-        CCACHE_NOCOMPRESS=1\
-        CCACHE_SLOPPINESS=time_macros,include_file_ctime,include_file_mtime
+        CCACHE_NOCOMPRESS=1 \
+        CCACHE_SLOPPINESS=time_macros,include_file_ctime,include_file_mtime \
         CCACHE_COMPILERCHECK=string:manyclangs-clang${BUILDER_CLANG_VERSION_SUFFIX} \
         "${NINJA}" -f build.patched.ninja |& tee -a build.log
     then

--- a/contrib/manyclangs-build-month
+++ b/contrib/manyclangs-build-month
@@ -34,6 +34,8 @@ _manyclangs_list_files0_to_pack() {
     find . -maxdepth 1 -type f \( \
             -name link.sh \
             -or -name README \
+            -or -name build.ninja \
+            -or -name rules.ninja \
             -or -name 'LICENSE*' \
             -or -name '*.log' \
             -or -name 'COMMIT_SHA' \

--- a/contrib/manyclangs-build-month
+++ b/contrib/manyclangs-build-month
@@ -69,7 +69,7 @@ _manyclangs_build_part() {
     HASHES_DIR=$PWD/hashes
     mkdir -p "$HASHES_DIR"
     mkdir -p "${GIT_WORK_TREE}/build"
-    cd "${GIT_WORK_TREE}/build"
+    pushd "${GIT_WORK_TREE}/build"
     ln -frs "${ELFSHAKER_DATA}" elfshaker_data
 
     # CCACHE_BASEDIR causes ccache to rewrite arguments to the compiler to be
@@ -110,6 +110,8 @@ _manyclangs_build_part() {
 
         echo Built "$SNAPSHOT_NAME" 1>&30 # for pv progress output.
     done < "${COMMIT_LIST}"
+
+    popd
 
     if [[ -z "${MANYCLANGS_NODELETE-}" ]]
     then

--- a/contrib/manyclangs-build-month
+++ b/contrib/manyclangs-build-month
@@ -168,6 +168,8 @@ apply_subset() {
 }
 
 main() {
+    BUILDER_CLANG_VERSION_SUFFIX=${BUILDER_CLANG_VERSION_SUFFIX--12}
+
     sanity_check
 
     echo
@@ -175,8 +177,6 @@ main() {
     YEAR="$1"
     MONTH="$2"
     date -d "$YEAR/$MONTH/01" 1>/dev/null || { print_help; exit 1; }
-
-    BUILDER_CLANG_VERSION_SUFFIX=${BUILDER_CLANG_VERSION_SUFFIX--12}
 
     commits_for_month "$YEAR" "$MONTH"  > manyclangs-commit-list.txt
     apply_limit < manyclangs-commit-list.txt | apply_subset > manyclangs-commit-list.txt.subset

--- a/contrib/manyclangs-build-month
+++ b/contrib/manyclangs-build-month
@@ -24,7 +24,7 @@ commits_for_month() {
     fi
 
     git-list-between origin/main \
-        "$YEAR/$MONTH/01" "$NEXT_YEAR/$NEXT_MONTH/01" -- llvm clang
+        "$YEAR/$MONTH/01" "$NEXT_YEAR/$NEXT_MONTH/01" -- llvm clang cmake
 }
 
 _manyclangs_list_files0_to_pack() {
@@ -81,13 +81,22 @@ _manyclangs_build_part() {
     while read -r COMMIT_SHA SNAPSHOT_NAME
     do
         echo "Building commit $SNAPSHOT_NAME"
+
+        EXTRA=()
+        # Detect the cmake top-level directory introduced Jan 2022.
+        if git ls-tree "$COMMIT_SHA":cmake &> /dev/null;
+        then
+            EXTRA+=(cmake)
+        fi
+
         # Handy comand which sets the sources in ./llvm ./clang to the right
         # contents efficiently (including removing files which have gone). It
         # makes use of the $GIT_INDEX_FILE to keep track of the old state so is
         # efficient.
-        GIT_WORK_TREE=.. \
-        git restore --no-progress --staged --worktree --source="$COMMIT_SHA" -- \
-            ../{llvm,clang} :^../{llvm,clang}/test
+        (cd .. &&
+         git restore --no-progress --staged --worktree --source="$COMMIT_SHA" -- \
+             {llvm,clang} :^{llvm,clang}/test "${EXTRA[@]}"
+        )
 
         echo "$COMMIT_SHA" > COMMIT_SHA
         date


### PR DESCRIPTION
This fixes a few issues I've encountered in the build scripts. Please see the individual commits.

* `link.sh` should report an error if the prerequisites are missing (elfshaker/manyclangs#5).
* Remove the filter_dupes hack and use --start-lib and --end-lib which does the same thing but better, providing binaries which should be equivalent to those you'd get if you had build the archives.
* Fix a bug where comm and jq could diverge.
* Other minor cleanups.