### PR TITLE
Use deserialize_only_snapshots and clippy fixes

### DIFF
--- a/src/atomicfile.rs
+++ b/src/atomicfile.rs
@@ -162,7 +162,7 @@ impl<'l> AtomicCreateFile<'l> {
     pub fn commit_content(mut self, mut r: impl Read) -> io::Result<()> {
         let written = io::copy(&mut r, &mut self.temp.1)?;
         assert!(
-            !(written == 0),
+            written != 0,
             "written == 0 in commit_content; \
              AtomicCreateFile assumes non-empty files",
         );

--- a/src/bin/elfshaker/find.rs
+++ b/src/bin/elfshaker/find.rs
@@ -14,7 +14,7 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
 
     let mut table = vec![];
     for pack_id in repo.packs()? {
-        for snapshot in repo.load_index(&pack_id)?.snapshot_tags() {
+        for snapshot in repo.load_index_snapshots(&pack_id)? {
             table.push([snapshot.to_string(), pack_id.to_string()])
         }
     }
@@ -23,10 +23,9 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
         .packs()?
         .into_iter()
         .flat_map(|p| {
-            repo.load_index(&p).map(|pack_index| {
+            repo.load_index_snapshots(&p).map(|pack_index| {
                 pack_index
-                    .snapshot_tags()
-                    .iter()
+                    .into_iter()
                     .filter_map(|s| {
                         s.contains(term)
                             .then(|| std::array::IntoIter::new([s.to_string(), p.to_string()]))

--- a/src/bin/elfshaker/find.rs
+++ b/src/bin/elfshaker/find.rs
@@ -28,14 +28,14 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
                     .into_iter()
                     .filter_map(|s| {
                         s.contains(term)
-                            .then(|| std::array::IntoIter::new([s.to_string(), p.to_string()]))
+                            .then(|| IntoIterator::into_iter([s.to_string(), p.to_string()]))
                     })
                     .collect::<Vec<_>>()
             })
         })
         .flatten();
 
-    let i = std::array::IntoIter::new(["SNAPSHOT".to_owned(), "PACK".to_owned()]);
+    let i = IntoIterator::into_iter(["SNAPSHOT".to_owned(), "PACK".to_owned()]);
     print_table(Some(i), table);
     Ok(())
 }

--- a/src/bin/elfshaker/list.rs
+++ b/src/bin/elfshaker/list.rs
@@ -52,7 +52,7 @@ fn print_repo_summary(repo: &Repository, bytes: bool) -> Result<(), Box<dyn Erro
     let mut table = vec![];
 
     for pack_id in repo.packs()? {
-        let pack_index = repo.load_index(&pack_id)?;
+        let pack_index = repo.load_index_snapshots(&pack_id)?;
 
         let size_str = match repo.open_pack(&pack_id) {
             Ok(pack) => if bytes { pack.file_size().to_string() } else { format_size(pack.file_size()) },
@@ -63,7 +63,7 @@ fn print_repo_summary(repo: &Repository, bytes: bool) -> Result<(), Box<dyn Erro
             match pack_id {
                 PackId::Pack(s) => s,
             },
-            pack_index.snapshot_tags().len().to_string(),
+            pack_index.len().to_string(),
             size_str,
         ]);
     }

--- a/src/bin/elfshaker/pack.rs
+++ b/src/bin/elfshaker/pack.rs
@@ -27,7 +27,7 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
         .values_of("indexes")
         .map(|opts| {
             opts.into_iter()
-                .map(|s| PackId::from_str(s))
+                .map(PackId::from_str)
                 .collect::<Result<Vec<_>, _>>()
         })
         .transpose()?;

--- a/src/bin/elfshaker/show.rs
+++ b/src/bin/elfshaker/show.rs
@@ -19,10 +19,6 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
     let snapshot = repo.find_snapshot(snapshot)?;
     let pack_index = repo.load_index(snapshot.pack())?;
 
-    // pack_index.resolve_snapshot(needle)
-    // let entries: HashMap<_, _> = pack_index
-    //     .entries_from_snapshot(snapshot.tag())?
-
     let entries: HashMap<_, _> = pack_index
         .entries_from_handles(
             pack_index

--- a/src/packidx.rs
+++ b/src/packidx.rs
@@ -450,6 +450,14 @@ impl PackIndex {
         Ok(rmp_serde::decode::from_read(rd)?)
     }
 
+    pub fn load_only_snapshots<P: AsRef<Path>>(p: P) -> Result<Vec<String>, PackError> {
+        let rd = open_file(p.as_ref())?;
+        let mut rd = BufReader::new(rd);
+        Self::read_magic(&mut rd)?;
+        let mut d = rmp_serde::Deserializer::new(rd);
+        Ok(PackIndex::deserialize_only_snapshots(&mut d)?.snapshot_tags)
+    }
+
     pub fn save<P: AsRef<Path>>(&self, p: P) -> Result<(), PackError> {
         // TODO: Use AtomicCreateFile.
         let wr = create_file(p.as_ref())?;

--- a/src/repo/algo.rs
+++ b/src/repo/algo.rs
@@ -16,7 +16,7 @@ where
     Item: Send,
     Output: Send,
 {
-    assert!(!(nthread == 0), "nthread == 0");
+    assert!(nthread != 0, "nthread == 0");
     crossbeam_utils::thread::scope(|s| {
         let mut workers = Vec::new();
         let mut items = items.peekable();

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -819,7 +819,7 @@ where
     P: AsRef<Path>,
 {
     let files = files
-        .map(|p| {
+        .flat_map(|p| {
             if p.as_ref().is_relative() {
                 Ok(p)
             } else {
@@ -829,7 +829,6 @@ where
                 ))
             }
         })
-        .flatten()
         .map(|p| {
             Ok(p.as_ref()
                 .canonicalize()?


### PR DESCRIPTION
This represents a pretty significant improvement for the loading times for various operations in a repository with a large number of packs and snapshots. I've looked at all uses of `load_index` and replaced them with `load_index_snapshots` where only the snapshot names or count is used.

For me, this reduces the CPU time to list from 3s down to 10ms, and the win comes from not parsing the whole index.