### PR TITLE
New elfshaker list behaviour

### DIFF
--- a/src/bin/elfshaker/list_files.rs
+++ b/src/bin/elfshaker/list_files.rs
@@ -1,0 +1,91 @@
+//! SPDX-License-Identifier: Apache-2.0
+//! Copyright (C) 2021 Arm Limited or its affiliates and Contributors. All rights reserved.
+
+use clap::{App, Arg, ArgMatches};
+use std::{error::Error, ffi::OsStr};
+
+use super::utils::{format_size, open_repo_from_cwd};
+use elfshaker::packidx::ObjectChecksum;
+use elfshaker::repo::{Repository, SnapshotId};
+
+pub(crate) const SUBCOMMAND: &str = "list-files";
+
+pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    let snapshot = matches
+        .value_of_lossy("snapshot")
+        .expect("expected snapshot");
+    let format = matches
+        .value_of_lossy("format")
+        .expect("<format> not provided");
+
+    let repo = open_repo_from_cwd()?;
+
+    let snapshot_id = repo.find_snapshot(&snapshot)?;
+
+    print_files(&repo, &snapshot_id, &format)?;
+
+    Ok(())
+}
+
+pub(crate) fn get_app() -> App<'static, 'static> {
+    App::new(SUBCOMMAND)
+        .about("Prints the list of files available in the snapshot.")
+        .arg(
+            Arg::with_name("snapshot")
+                .index(1)
+                .required(true)
+                .help("Prints the contents of the specified snapshot."),
+        )
+        .arg(
+            Arg::with_name("format")
+                .long("format")
+                .default_value("%o %f %b")
+                .help(
+                    "Pretty-print each result in the given format, where \
+                    <format> is a string containing one or more of the \
+                    following placeholders:\n\
+                    \t%o - file checksum\n\
+                    \t%f - file name\n\
+                    \t%h - human-readable size\n\
+                    \t%b - size in bytes\n",
+                ),
+        )
+}
+
+fn format_file_row(fmt: &str, checksum: &ObjectChecksum, file_name: &OsStr, size: u64) -> String {
+    fmt.to_owned()
+        .replace("%o", &hex::encode(&checksum))
+        .replace("%f", &file_name.to_string_lossy())
+        .replace("%h", &format_size(size))
+        .replace("%b", &size.to_string())
+}
+
+fn print_files(
+    repo: &Repository,
+    snapshot_id: &SnapshotId,
+    fmt: &str,
+) -> Result<(), Box<dyn Error>> {
+    let mut lines = vec![];
+
+    let index = repo.load_index(snapshot_id.pack())?;
+    let handles = index
+        .resolve_snapshot(snapshot_id.tag())
+        .expect("failed to resolve snapshot");
+
+    for entry in index.entries_from_handles(handles.iter())? {
+        lines.push(format_file_row(
+            fmt,
+            &entry.checksum,
+            &entry.path,
+            entry.metadata.size,
+        ));
+    }
+
+    lines.sort();
+
+    for line in lines {
+        println!("{}", line);
+    }
+
+    Ok(())
+}

--- a/src/bin/elfshaker/list_packs.rs
+++ b/src/bin/elfshaker/list_packs.rs
@@ -1,0 +1,70 @@
+//! SPDX-License-Identifier: Apache-2.0
+//! Copyright (C) 2021 Arm Limited or its affiliates and Contributors. All rights reserved.
+
+use clap::{App, Arg, ArgMatches};
+use std::error::Error;
+
+use super::utils::{format_size, open_repo_from_cwd};
+use elfshaker::repo::{PackId, Repository};
+
+pub(crate) const SUBCOMMAND: &str = "list-packs";
+
+pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    let format = matches
+        .value_of_lossy("format")
+        .expect("<format> not provided");
+
+    let repo = open_repo_from_cwd()?;
+
+    print_packs(&repo, &format)?;
+
+    Ok(())
+}
+
+pub(crate) fn get_app() -> App<'static, 'static> {
+    App::new(SUBCOMMAND)
+        .about("Prints the list of packs available in the repository.")
+        .arg(
+            Arg::with_name("format")
+                .long("format")
+                .default_value("%p")
+                .help(
+                    "Pretty-print each result in the given format, where \
+                    <format> is a string containing one or more of the \
+                    following placeholders:\n\
+                    \t%p - pack\n\
+                    \t%h - human-readable size\n\
+                    \t%b - size in bytes\n\
+                    \t%c - number of snapshots\n",
+                ),
+        )
+}
+
+fn format_pack_row(fmt: &str, pack_id: &PackId, snapshot_count: usize, size: u64) -> String {
+    fmt.to_owned()
+        .replace("%p", &format!("{}", pack_id))
+        .replace("%c", &snapshot_count.to_string())
+        .replace("%b", &size.to_string())
+        .replace("%h", &format_size(size))
+}
+
+fn print_packs(repo: &Repository, fmt: &str) -> Result<(), Box<dyn Error>> {
+    let mut lines = vec![];
+
+    for pack_id in repo.packs()? {
+        let snapshot_count = repo.load_index_snapshots(&pack_id)?.len();
+        let pack_size = repo
+            .open_pack(&pack_id)
+            .map(|pack| pack.file_size())
+            .unwrap_or(0);
+        lines.push(format_pack_row(fmt, &pack_id, snapshot_count, pack_size));
+    }
+
+    lines.sort();
+
+    for line in lines {
+        println!("{}", line);
+    }
+
+    Ok(())
+}

--- a/src/bin/elfshaker/main.rs
+++ b/src/bin/elfshaker/main.rs
@@ -5,6 +5,8 @@ mod clone;
 mod extract;
 mod find;
 mod list;
+mod list_files;
+mod list_packs;
 mod pack;
 mod show;
 mod store;
@@ -44,6 +46,8 @@ fn run_subcommand(app: &mut App, matches: ArgMatches) -> Result<(), Box<dyn Erro
         (extract::SUBCOMMAND, Some(matches)) => extract::run(matches),
         (store::SUBCOMMAND, Some(matches)) => store::run(matches),
         (list::SUBCOMMAND, Some(matches)) => list::run(matches),
+        (list_packs::SUBCOMMAND, Some(matches)) => list_packs::run(matches),
+        (list_files::SUBCOMMAND, Some(matches)) => list_files::run(matches),
         (pack::SUBCOMMAND, Some(matches)) => pack::run(matches),
         (show::SUBCOMMAND, Some(matches)) => show::run(matches),
         (find::SUBCOMMAND, Some(matches)) => find::run(matches),
@@ -62,6 +66,8 @@ fn get_app() -> App<'static, 'static> {
         .subcommand(extract::get_app())
         .subcommand(store::get_app())
         .subcommand(list::get_app())
+        .subcommand(list_packs::get_app())
+        .subcommand(list_files::get_app())
         .subcommand(pack::get_app())
         .subcommand(show::get_app())
         .subcommand(find::get_app())

--- a/src/bin/elfshaker/utils.rs
+++ b/src/bin/elfshaker/utils.rs
@@ -93,7 +93,14 @@ where
 
 /// Formats file sizes to human-readable format.
 pub fn format_size(bytes: u64) -> String {
-    format!("{:.3}MiB", bytes as f64 / 1024.0 / 1024.0)
+    let mut value = bytes as f64;
+    for unit in ["B", "K", "M", "G", "T"] {
+        if value < 1024.0 {
+            return format!("{}{}", (value * 1000.0).round() / 1000.0, unit);
+        }
+        value /= 1024.0;
+    }
+    unreachable!()
 }
 
 /// Opens the repo from the current work directory and logs some standard


### PR DESCRIPTION
elfshaker list has been split into several commands.

- elfshaker list <pack>... lists the snapshots in the packs
- elfshaker list-files <snapshot> lists the files in the snapshot
- elfshaker list-packs lists the packs in the repo

```
elfshaker-list 
Prints the list of snapshots available in the repository.

USAGE:
    elfshaker list [FLAGS] [OPTIONS] [pack]...

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
        --verbose    Enables verbose description of the execution process.

OPTIONS:
        --format <format>    Pretty-print each result in the given format, where <format> is a string containing one or
                             more of the following placeholders:
                                %s - fully-qualified snapshot
                                %t - snapshot tag
                                %h - human-readable size
                                %b - size in bytes
                                %n - number of files
                              [default: %s]

ARGS:
    <pack>...    Prints the contents of the specified packs.

elfshaker-list-packs 
Prints the list of packs available in the repository.

USAGE:
    elfshaker list-packs [FLAGS] [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
        --verbose    Enables verbose description of the execution process.

OPTIONS:
        --format <format>    Pretty-print each result in the given format, where <format> is a string containing one or
                             more of the following placeholders:
                                %p - pack
                                %h - human-readable size
                                %b - size in bytes
                                %c - number of snapshots
                              [default: %p]

elfshaker-list-files 
Prints the list of files available in the snapshot.

USAGE:
    elfshaker list-files [FLAGS] [OPTIONS] <snapshot>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
        --verbose    Enables verbose description of the execution process.

OPTIONS:
        --format <format>    Pretty-print each result in the given format, where <format> is a string containing one or
                             more of the following placeholders:
                                %o - file checksum
                                %f - file name
                                %h - human-readable size
                                %b - size in bytes
                              [default: %o %f %b]

ARGS:
    <snapshot>    Prints the contents of the specified snapshot.
```

Closes #74.