### PR TITLE
Support changing of the elfshaker data directory

### DIFF
--- a/src/bin/elfshaker/extract.rs
+++ b/src/bin/elfshaker/extract.rs
@@ -13,6 +13,7 @@ use elfshaker::repo::{Error as RepoError, ExtractOptions};
 pub(crate) const SUBCOMMAND: &str = "extract";
 
 pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    let data_dir = std::path::Path::new(matches.value_of("data_dir").unwrap());
     let snapshot = matches.value_of("snapshot").unwrap();
     let is_reset = matches.is_present("reset");
     let is_verify = matches.is_present("verify");
@@ -31,7 +32,7 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
         n => n,
     };
 
-    let mut repo = open_repo_from_cwd()?;
+    let mut repo = open_repo_from_cwd(data_dir)?;
     let new_head = match repo.find_snapshot(snapshot) {
         Err(RepoError::PackError(PackError::SnapshotNotFound(_))) => {
             info!("Snapshot not available locally. Updating remotes...");

--- a/src/bin/elfshaker/find.rs
+++ b/src/bin/elfshaker/find.rs
@@ -9,8 +9,9 @@ use super::utils::{open_repo_from_cwd, print_table};
 pub(crate) const SUBCOMMAND: &str = "find";
 
 pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    let data_dir = std::path::Path::new(matches.value_of("data_dir").unwrap());
     let term = matches.value_of("term").unwrap();
-    let repo = open_repo_from_cwd()?;
+    let repo = open_repo_from_cwd(data_dir)?;
 
     let mut table = vec![];
     for pack_id in repo.packs()? {

--- a/src/bin/elfshaker/list.rs
+++ b/src/bin/elfshaker/list.rs
@@ -10,12 +10,13 @@ use elfshaker::repo::{PackId, Repository};
 pub(crate) const SUBCOMMAND: &str = "list";
 
 pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    let data_dir = std::path::Path::new(matches.value_of("data_dir").unwrap());
     let packs = matches.values_of_lossy("pack");
     let format = matches
         .value_of_lossy("format")
         .expect("<format> not provided");
 
-    let repo = open_repo_from_cwd()?;
+    let repo = open_repo_from_cwd(data_dir)?;
 
     let packs = packs
         .map(|packs| packs.iter().cloned().map(PackId::Pack).collect())

--- a/src/bin/elfshaker/list_files.rs
+++ b/src/bin/elfshaker/list_files.rs
@@ -11,6 +11,7 @@ use elfshaker::repo::{Repository, SnapshotId};
 pub(crate) const SUBCOMMAND: &str = "list-files";
 
 pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    let data_dir = std::path::Path::new(matches.value_of("data_dir").unwrap());
     let snapshot = matches
         .value_of_lossy("snapshot")
         .expect("expected snapshot");
@@ -18,7 +19,7 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
         .value_of_lossy("format")
         .expect("<format> not provided");
 
-    let repo = open_repo_from_cwd()?;
+    let repo = open_repo_from_cwd(data_dir)?;
 
     let snapshot_id = repo.find_snapshot(&snapshot)?;
 

--- a/src/bin/elfshaker/list_packs.rs
+++ b/src/bin/elfshaker/list_packs.rs
@@ -10,11 +10,12 @@ use elfshaker::repo::{PackId, Repository};
 pub(crate) const SUBCOMMAND: &str = "list-packs";
 
 pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    let data_dir = std::path::Path::new(matches.value_of("data_dir").unwrap());
     let format = matches
         .value_of_lossy("format")
         .expect("<format> not provided");
 
-    let repo = open_repo_from_cwd()?;
+    let repo = open_repo_from_cwd(data_dir)?;
 
     print_packs(&repo, &format)?;
 

--- a/src/bin/elfshaker/main.rs
+++ b/src/bin/elfshaker/main.rs
@@ -79,4 +79,13 @@ fn get_app() -> App<'static, 'static> {
                 .help("Enables verbose description of the execution process.")
                 .global(true),
         )
+        .arg(
+            Arg::with_name("data_dir")
+                .long("data-dir")
+                .env("ELFSHAKER_DATA")
+                .hide_env_values(true)
+                .help("Set the path to the elfshaker repository.")
+                .default_value(elfshaker::repo::REPO_DIR)
+                .global(true),
+        )
 }

--- a/src/bin/elfshaker/pack.rs
+++ b/src/bin/elfshaker/pack.rs
@@ -20,6 +20,7 @@ pub(crate) const SUBCOMMAND: &str = "pack";
 const DEFAULT_COMPRESSION_WINDOW_LOG: u32 = 28;
 
 pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    let data_dir = std::path::Path::new(matches.value_of("data_dir").unwrap());
     // Parse pack name
     let pack = matches.value_of("pack").unwrap();
     let pack = PackId::from_str(pack)?;
@@ -58,7 +59,7 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
         n => n,
     };
 
-    let mut repo = open_repo_from_cwd()?;
+    let mut repo = open_repo_from_cwd(data_dir)?;
 
     let indexes = indexes
         .map(Result::Ok)

--- a/src/bin/elfshaker/show.rs
+++ b/src/bin/elfshaker/show.rs
@@ -12,10 +12,11 @@ use elfshaker::repo::ExtractOptions;
 pub(crate) const SUBCOMMAND: &str = "show";
 
 pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    let data_dir = std::path::Path::new(matches.value_of("data_dir").unwrap());
     let snapshot = matches.value_of("snapshot").unwrap();
     let paths: Vec<_> = matches.values_of_os("path").unwrap().collect();
 
-    let mut repo = open_repo_from_cwd()?;
+    let mut repo = open_repo_from_cwd(data_dir)?;
     let snapshot = repo.find_snapshot(snapshot)?;
     let pack_index = repo.load_index(snapshot.pack())?;
 

--- a/src/bin/elfshaker/store.rs
+++ b/src/bin/elfshaker/store.rs
@@ -7,11 +7,12 @@ use std::{error::Error, ffi::OsStr, fs, io, path::PathBuf};
 use walkdir::WalkDir;
 
 use super::utils::open_repo_from_cwd;
-use elfshaker::repo::{PackId, Repository, SnapshotId};
+use elfshaker::repo::{PackId, SnapshotId};
 
 pub(crate) const SUBCOMMAND: &str = "store";
 
 pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    let data_dir = std::path::Path::new(matches.value_of("data_dir").unwrap());
     let files_from = matches.value_of("files-from");
     let files0_from = matches.value_of("files0-from");
     let snapshot = matches.value_of("snapshot").unwrap();
@@ -35,9 +36,9 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
         _ => find_files(),
     };
 
-    fs::create_dir_all(PathBuf::from(".").join(&*Repository::data_dir()))?;
+    fs::create_dir_all(data_dir)?;
 
-    let mut repo = open_repo_from_cwd()?;
+    let mut repo = open_repo_from_cwd(data_dir)?;
     repo.create_snapshot(&snapshot, files.into_iter())?;
 
     Ok(())

--- a/src/bin/elfshaker/update.rs
+++ b/src/bin/elfshaker/update.rs
@@ -8,8 +8,9 @@ use super::utils::{create_percentage_print_reporter, open_repo_from_cwd};
 
 pub(crate) const SUBCOMMAND: &str = "update";
 
-pub(crate) fn run(_matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
-    let mut repo = open_repo_from_cwd()?;
+pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    let data_dir = std::path::Path::new(matches.value_of("data_dir").unwrap());
+    let mut repo = open_repo_from_cwd(data_dir)?;
 
     repo.set_progress_reporter(|msg| create_percentage_print_reporter(msg, 5));
     repo.update_remotes()?;

--- a/src/bin/elfshaker/utils.rs
+++ b/src/bin/elfshaker/utils.rs
@@ -8,6 +8,7 @@ use elfshaker::repo::{Error as RepoError, Repository};
 use lazy_static::lazy_static;
 use log::info;
 use std::io::Write;
+use std::path::Path;
 use std::sync::{
     atomic::{AtomicIsize, Ordering},
     Arc,
@@ -107,11 +108,11 @@ pub fn format_size(bytes: u64) -> String {
 
 /// Opens the repo from the current work directory and logs some standard
 /// stats about the process.
-pub fn open_repo_from_cwd() -> Result<Repository, RepoError> {
+pub fn open_repo_from_cwd(data_dir: &Path) -> Result<Repository, RepoError> {
     // Open repo from cwd.
     let repo_path = std::env::current_dir()?;
     info!("Opening repository...");
-    let (elapsed, open_result) = measure(|| Repository::open(&repo_path));
+    let (elapsed, open_result) = measure(|| Repository::open_with_data_dir(repo_path, data_dir));
     info!("Opening repository took {:?}", elapsed);
     open_result
 }

--- a/src/repo/constants.rs
+++ b/src/repo/constants.rs
@@ -1,9 +1,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //! Copyright (C) 2021 Arm Limited or its affiliates and Contributors. All rights reserved.
 
-/// Use [`super::Repository::data_dir`] instead of REPO_DIR
-/// This will make is easier to make this value user-configurable
-/// in the future.
+/// The default repository directory.
 pub const REPO_DIR: &str = "elfshaker_data";
 /// The top-level index file path.
 pub const INDEX_FILE: &str = "index";

--- a/src/repo/pack.rs
+++ b/src/repo/pack.rs
@@ -24,7 +24,6 @@ use super::constants::{
 };
 use super::error::Error;
 use super::fs::{create_file, open_file};
-use super::repository::Repository;
 use super::{algo::run_in_parallel, constants::DOT_PACK_INDEX_EXTENSION};
 use crate::packidx::{FileEntry, ObjectChecksum, PackError};
 use crate::{log::measure_ok, packidx::ObjectMetadata};
@@ -291,13 +290,12 @@ impl Pack {
     /// # Arguments
     ///
     /// * `pack_name` - The base filename ([`Path::file_stem`]) of the pack.
-    pub fn open<P>(repo: P, pack_name: &PackId) -> Result<Self, Error>
+    pub fn open<P>(data_dir: P, pack_name: &PackId) -> Result<Self, Error>
     where
         P: AsRef<Path>,
     {
         let PackId::Pack(pack_name) = pack_name;
-        let mut packs_data = repo.as_ref().join(&*Repository::data_dir());
-        packs_data.push(PACKS_DIR);
+        let packs_data = data_dir.as_ref().join(PACKS_DIR);
 
         let mut pack_index_path = packs_data.join(pack_name);
         pack_index_path.set_extension(PACK_INDEX_EXTENSION);

--- a/test-scripts/check.sh
+++ b/test-scripts/check.sh
@@ -188,6 +188,20 @@ test_store_empty_directory_works() {
   [ "$("$elfshaker" list | wc -l)" -eq 1 ]
 }
 
+test_store_data_dir_works() {
+  mkdir -p testdir
+  cd testdir
+
+  "$elfshaker" --verbose --data-dir=../data_dir store test
+
+  if [[ -d "elfshaker_data" ]]; then
+    echo "elfshaker_data should not have been created!";
+    exit 1
+  fi
+
+  [ "$("$elfshaker" --verbose --data-dir=../data_dir list | wc -l)" -eq 1 ]
+}
+
 rand_megs() {
   dd if=/dev/urandom bs="$1M" count=1 iflag=fullblock
 }
@@ -479,6 +493,7 @@ main() {
   run_test test_store_twice_works
   run_test test_store_finds_new_files
   run_test test_store_empty_directory_works
+  run_test test_store_data_dir_works
   run_test test_pack_simple_works
   run_test test_pack_two_snapshots_works
   run_test test_pack_two_snapshots_object_sort_works


### PR DESCRIPTION
Allow the user to specify an alternative path for the elfshaker repository directory (elfshaker_data) via `--data-dir`.

Related: #86 