### PR TITLE
Refactor: Version the PackIndex structure

### DIFF
--- a/src/bin/elfshaker/list.rs
+++ b/src/bin/elfshaker/list.rs
@@ -6,6 +6,7 @@ use elfshaker::repo::run_in_parallel;
 use std::{error::Error, ops::ControlFlow};
 
 use super::utils::{format_size, open_repo_from_cwd};
+use elfshaker::packidx::PackIndex;
 use elfshaker::repo::{PackId, Repository};
 
 pub(crate) const SUBCOMMAND: &str = "list";

--- a/src/bin/elfshaker/list_files.rs
+++ b/src/bin/elfshaker/list_files.rs
@@ -5,7 +5,7 @@ use clap::{App, Arg, ArgMatches};
 use std::{error::Error, ffi::OsStr};
 
 use super::utils::{format_size, open_repo_from_cwd};
-use elfshaker::packidx::ObjectChecksum;
+use elfshaker::packidx::{ObjectChecksum, PackIndex};
 use elfshaker::repo::{Repository, SnapshotId};
 
 pub(crate) const SUBCOMMAND: &str = "list-files";

--- a/src/bin/elfshaker/pack.rs
+++ b/src/bin/elfshaker/pack.rs
@@ -7,7 +7,7 @@ use std::{error::Error, ops::ControlFlow, str::FromStr};
 
 use super::utils::{create_percentage_print_reporter, open_repo_from_cwd};
 use elfshaker::{
-    packidx::PackIndex,
+    packidx::{PackIndex, VerPackIndex},
     repo::{PackId, PackOptions, SnapshotId},
 };
 
@@ -70,7 +70,7 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
         return Err("There are no loose snapshots!".into());
     }
 
-    let mut new_index = PackIndex::new();
+    let mut new_index = VerPackIndex::new();
 
     for pack_id in &indexes {
         assert!(

--- a/src/bin/elfshaker/show.rs
+++ b/src/bin/elfshaker/show.rs
@@ -6,6 +6,7 @@ use rand::RngCore;
 use std::{collections::HashMap, error::Error};
 
 use super::utils::open_repo_from_cwd;
+use elfshaker::packidx::PackIndex;
 use elfshaker::repo::fs::open_file;
 use elfshaker::repo::ExtractOptions;
 

--- a/src/entrypool.rs
+++ b/src/entrypool.rs
@@ -57,7 +57,7 @@ where
         self.entries.get(h as usize)
     }
 
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = &T> {
+    pub fn iter(&self) -> std::slice::Iter<T> {
         self.entries.iter()
     }
 }

--- a/src/repo/remote.rs
+++ b/src/repo/remote.rs
@@ -16,7 +16,7 @@ use url::Url;
 use super::constants::{PACK_EXTENSION, REMOTE_INDEX_EXTENSION};
 use super::error::Error;
 use super::fs::{create_file, open_file};
-use crate::packidx::{ObjectChecksum, PackIndex};
+use crate::packidx::{ObjectChecksum, PackIndex, VerPackIndex};
 use crate::progress::{ProgressReporter, ProgressWriter};
 
 const HTTP_STATUS_OK: u16 = 200;
@@ -368,14 +368,16 @@ fn read_remote_resource(
     if_modified_since: Option<SystemTime>,
 ) -> Result<Option<Vec<u8>>, Error> {
     open_remote_resource(agent, url, Some(timeout), if_modified_since).and_then(|opt_reader| {
-        opt_reader.map(|mut reader| {
-            let mut body: Vec<u8> = vec![];
-            reader
-                .1
-                .read_to_end(&mut body)
-                .map_err(|e| Error::HttpError(e.into()))
-                .map(|_| body)
-        }).map_or(Ok(None), |v| v.map(Some))
+        opt_reader
+            .map(|mut reader| {
+                let mut body: Vec<u8> = vec![];
+                reader
+                    .1
+                    .read_to_end(&mut body)
+                    .map_err(|e| Error::HttpError(e.into()))
+                    .map(|_| body)
+            })
+            .map_or(Ok(None), |v| v.map(Some))
     })
 }
 
@@ -392,7 +394,9 @@ pub fn update_remote_pack(
         .and_then(|x| x.modified().ok());
 
     let url = remote_pack.url.parse::<Url>().unwrap();
-    if let Some((content_length, mut reader)) = open_remote_resource(agent, &url, None, date_modified)? {
+    if let Some((content_length, mut reader)) =
+        open_remote_resource(agent, &url, None, date_modified)?
+    {
         let mut data = vec![];
 
         let mut writer = ProgressWriter::with_known_size(&mut data, reporter, content_length);
@@ -452,15 +456,11 @@ fn update_pack_index(agent: &Agent, url: &Url, pack_index_path: &Path) -> Result
         .ok()
         .and_then(|x| x.modified().ok());
 
-    let pack_index_bytes = read_remote_resource(
-        agent,
-        url,
-        Duration::from_secs(15),
-        date_modified,
-    )?;
+    let pack_index_bytes =
+        read_remote_resource(agent, url, Duration::from_secs(15), date_modified)?;
 
     if let Some(pack_index_bytes) = pack_index_bytes {
-        if let Err(e) = PackIndex::parse(pack_index_bytes.as_slice()) {
+        if let Err(e) = VerPackIndex::parse(pack_index_bytes.as_slice()) {
             log::error!(
                 "Failed to fetch {} from remote: The remote returned a broken .pack.idx! {}",
                 url,
@@ -481,11 +481,12 @@ fn update_pack_index(agent: &Agent, url: &Url, pack_index_path: &Path) -> Result
 /// Fetches the remote index from the server.
 pub fn fetch_remote(agent: &Agent, url: &str, path: &Path) -> Result<RemoteIndex, Error> {
     let url = url.parse::<Url>().unwrap();
-    let response =
-        read_remote_resource(agent, &url, Duration::from_secs(15), None)?;
+    let response = read_remote_resource(agent, &url, Duration::from_secs(15), None)?;
 
     match response {
-        None => unreachable!("Unexpected Not-Modified response from server given previously unseen resource"),
+        None => unreachable!(
+            "Unexpected Not-Modified response from server given previously unseen resource"
+        ),
         Some(data) => {
             let mut remote = RemoteIndex::read(BufReader::new(data.as_slice())).reify(url)?;
             // Update the .esi
@@ -511,12 +512,7 @@ pub fn update_remote(agent: &Agent, remote: &RemoteIndex) -> Result<RemoteIndex,
     // Read the modification date of the .esi.
     let date_modified = fs::metadata(path).ok().and_then(|x| x.modified().ok());
     let url = remote.url.parse::<Url>().unwrap();
-    let response = read_remote_resource(
-        agent,
-        &url,
-        Duration::from_secs(15),
-        date_modified,
-    )?;
+    let response = read_remote_resource(agent, &url, Duration::from_secs(15), date_modified)?;
 
     match response {
         // The local version is up-to-date.

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -26,7 +26,7 @@ use super::fs::{
 };
 use super::pack::{write_skippable_frame, Pack, PackFrame, PackHeader, PackId, SnapshotId};
 use super::remote;
-use crate::packidx::{FileEntry, ObjectChecksum, PackError, PackIndex};
+use crate::packidx::{FileEntry, ObjectChecksum, PackError, PackIndex, VerPackIndex};
 use crate::progress::ProgressReporter;
 use crate::{
     batch,
@@ -329,7 +329,7 @@ impl Repository {
         pack_index_path.exists()
     }
 
-    pub fn load_index(&self, pack_id: &PackId) -> Result<PackIndex, Error> {
+    pub fn load_index(&self, pack_id: &PackId) -> Result<VerPackIndex, Error> {
         let pack_index_path = match pack_id {
             PackId::Pack(name) => self
                 .data_dir()
@@ -338,7 +338,7 @@ impl Repository {
                 .with_extension(PACK_INDEX_EXTENSION),
         };
         info!("Load index {} {}", pack_id, pack_index_path.display());
-        Ok(PackIndex::load(pack_index_path)?)
+        Ok(VerPackIndex::load(pack_index_path)?)
     }
 
     pub fn load_index_snapshots(&self, pack_id: &PackId) -> Result<Vec<String>, Error> {
@@ -349,7 +349,7 @@ impl Repository {
                 .join(name)
                 .with_extension(PACK_INDEX_EXTENSION),
         };
-        Ok(PackIndex::load_only_snapshots(pack_index_path)?)
+        Ok(VerPackIndex::load_only_snapshots(pack_index_path)?)
     }
 
     /// Checks-out the specified snapshot.
@@ -567,7 +567,7 @@ impl Repository {
         .into_iter()
         .collect::<io::Result<Vec<_>>>()?;
 
-        let mut index = PackIndex::new();
+        let mut index = VerPackIndex::new();
         index.push_snapshot(snapshot.tag().to_owned(), pack_entries)?;
 
         let loose_path = self.data_dir().join(PACKS_DIR).join(LOOSE_DIR);
@@ -594,7 +594,7 @@ impl Repository {
     pub fn create_pack(
         &mut self,
         pack: &PackId,
-        index: PackIndex,
+        index: VerPackIndex,
         opts: &PackOptions,
         reporter: &ProgressReporter,
     ) -> Result<(), Error> {


### PR DESCRIPTION
Separated the PackIndex definition from its implementation into a PackIndex trait and PackIndexV1 struct.

Also added a `VerPackIndex` (versioned pack index) enum which will allow us to evolve the pack index format in the future, by handling the differences between the versions of the `PackIndex` in the `PackIndex` impl of the `VerPackIndex` enum.

The intention is to make it easier to evolve the pack index.