### PR TITLE
General maintenance: clippy, fmt, updates, add flake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,10 +20,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
+name = "android_system_properties"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
@@ -34,34 +43,34 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byteorder"
@@ -71,9 +80,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.68"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 dependencies = [
  "jobserver",
 ]
@@ -86,28 +95,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
- "libc",
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "time",
+ "wasm-bindgen",
  "winapi",
 ]
 
 [[package]]
-name = "chunked_transfer"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
-
-[[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -117,6 +122,22 @@ dependencies = [
  "unicode-width",
  "vec_map",
 ]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "crc32fast"
@@ -129,12 +150,55 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
- "lazy_static",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322296e2f2e5af4270b54df9e85a02ff037e271af20ba3e7fe1575515dc840b8"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "017a1385b05d631e7875b1f151c9f012d37b53491e2a87f65bff5c262b2111d8"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c26bbb078acf09bc1ecda02d4223f03bdd28bd4874edcb0379138efc499ce971"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357f40d1f06a24b60ae1fe122542c1fb05d28d32acb2aed064e84bc2ad1e252e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -151,7 +215,7 @@ dependencies = [
  "libc",
  "log",
  "num_cpus",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rmp-serde",
  "rust-crypto",
  "serde",
@@ -163,23 +227,20 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.22"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
- "cfg-if",
  "crc32fast",
- "libc",
  "miniz_oxide",
 ]
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -207,13 +268,13 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -227,9 +288,18 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -241,30 +311,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "idna"
-version = "0.2.3"
+name = "iana-time-zone"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
 dependencies = [
- "matches",
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.22"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.56"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -277,40 +370,42 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
-
-[[package]]
 name = "miniz_oxide"
-version = "0.4.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
- "autocfg",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -318,55 +413,61 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+
+[[package]]
+name = "paste"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -396,14 +497,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.3",
- "rand_hc",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -413,7 +513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -433,20 +533,11 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -475,12 +566,13 @@ dependencies = [
 
 [[package]]
 name = "rmp"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f55e5fa1446c4d5dd1f5daeed2a4fe193071771a2636274d0d7a3b082aa7ad6"
+checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
 dependencies = [
  "byteorder",
  "num-traits",
+ "paste",
 ]
 
 [[package]]
@@ -515,9 +607,9 @@ checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustls"
-version = "0.20.4"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -535,6 +627,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scratch"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,18 +644,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -578,13 +676,22 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -598,20 +705,20 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -624,30 +731,30 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.7"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "untrusted"
@@ -657,12 +764,11 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.4.0"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9399fa2f927a3d327187cbd201480cee55bee6ac5d3c77dd27f0c6814cff16d5"
+checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
 dependencies = [
  "base64",
- "chunked_transfer",
  "flate2",
  "log",
  "once_cell",
@@ -674,13 +780,12 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
 ]
 
@@ -714,10 +819,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.79"
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -725,13 +836,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.79"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -740,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.79"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -750,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.79"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -763,15 +874,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.79"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.56"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -789,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
 ]
@@ -829,18 +940,18 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zstd"
-version = "0.9.0+zstd.1.5.0"
+version = "0.9.2+zstd.1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07749a5dc2cb6b36661290245e350f15ec3bbb304e493db54a1d354480522ccd"
+checksum = "2390ea1bf6c038c39674f22d95f0564725fc06034a47129179810b2fc58caa54"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "4.1.1+zstd.1.5.0"
+version = "4.1.3+zstd.1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91c90f2c593b003603e5e0493c837088df4469da25aafff8bce42ba48caf079"
+checksum = "e99d81b99fb3c2c2c794e3fe56c305c63d5173a16a46b5850b07c935ffc7db79"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -848,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.6.1+zstd.1.5.0"
+version = "1.6.2+zstd.1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615120c7a2431d16cf1cf979e7fc31ba7a5b5e5707b29c8a99e5dbf8a8392a33"
+checksum = "2daf2f248d9ea44454bfcb2516534e8b8ad2fc91bf818a1885495fc42bc8ac9f"
 dependencies = [
  "cc",
  "libc",

--- a/docs/users/installing.md
+++ b/docs/users/installing.md
@@ -26,13 +26,13 @@ ln -s ~/.local/opt/elfshaker/elfshaker ~/.local/bin/elfshaker
 
 elfshaker is written in Rust, so you will need to install the Rust build system.
 - Install using rustup from https://www.rust-lang.org/tools/install
-- Install toolchain version 1.55
+- Install a stable toolchain (1.67 known to work, YMMV for older versions):
   - ```bash
-    rustup install 1.55
+    rustup install stable
     ```
 - Build elfshaker in Release mode
   - ```bash
-    cargo +1.55 build --release --bin elfshaker
+    cargo +stable build --release --bin elfshaker
     ```
   - ```bash
     ./target/release/elfshaker --help

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,105 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1674800601,
+        "narHash": "sha256-25OW8RylGrcGFhf5swfQLNjKRH87ltuvNgccrGKlKZ8=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "0a237d66ea3be2ae39fb4d279a4ae417bf38e2da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1655042882,
+        "narHash": "sha256-9BX8Fuez5YJlN7cdPO63InoyBy7dm3VlJkkmTt6fS1A=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "cddffb5aa211f50c4b8750adbec0bbbdfb26bb9f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "cddffb5aa211f50c4b8750adbec0bbbdfb26bb9f",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1672580127,
+        "narHash": "sha256-3lW3xZslREhJogoOkjeZtlBtvFMyxHku7I/9IVehhT8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0874168639713f547c05947c76124f78441ea46c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1674747430,
+        "narHash": "sha256-zXsp+LWyOZjjC3AjD1HXIntpnWuKnwdEaWI5zcSrBhc=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "9814d798411a4b1b258c710f86626bd1997e406f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,63 @@
+{
+  inputs = {
+    naersk.url = "github:nix-community/naersk/cddffb5aa211f50c4b8750adbec0bbbdfb26bb9f";
+    naersk.inputs.nixpkgs.follows = "nixpkgs";
+    fenix.url = "github:nix-community/fenix";
+    fenix.inputs.nixpkgs.follows = "nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-22.05";
+    utils.url = "github:numtide/flake-utils/7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249";
+  };
+
+  outputs = { self, nixpkgs, utils, naersk, fenix }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        naersk-lib = pkgs.callPackage naersk { };
+      in
+      {
+        defaultPackage = naersk-lib.buildPackage {
+          root = ./.;
+        };
+
+        defaultApp = utils.lib.mkApp {
+          drv = self.defaultPackage."${system}";
+        };
+
+        devShell = with pkgs; mkShell {
+          nativeBuildInputs = [
+            pre-commit
+            pkgs.pkgsStatic.buildPackages.gcc # aarch64-unknown-linux-musl-gcc
+            pkg-config
+            gcc
+            (python310.withPackages (pkgs: with pkgs; [
+              msgpack
+              ipython
+            ]))
+          ] ++ (with fenix.packages.${system}; [
+            (
+              combine [
+                stable.cargo
+                stable.clippy
+                rust-analyzer
+                stable.rust-src
+                stable.rustc
+                stable.rustfmt
+                targets.aarch64-unknown-linux-gnu.stable.rust-std
+                targets.aarch64-unknown-linux-musl.stable.rust-std
+                targets.x86_64-unknown-linux-musl.stable.rust-std
+              ]
+            )
+          ]);
+
+          CC_aarch64_unknown_linux_musl = "aarch64-unknown-linux-musl-gcc";
+          CC_aarch64_unknown_linux_gnu = "cc";
+
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS = "-L${pkgs.pkgsStatic.buildPackages.gcc.cc.lib}/aarch64-unknown-linux-musl/lib -lstatic=stdc++";
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER = "aarch64-unknown-linux-musl-ld";
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER = "cc";
+
+          NIX_PATH = "nixpkgs=${nixpkgs.outPath}";
+        };
+      });
+}
+

--- a/src/atomicfile.rs
+++ b/src/atomicfile.rs
@@ -199,7 +199,7 @@ fn create_temp_path<P: AsRef<Path>>(temp_dir: P) -> PathBuf {
     temp_filename.push_str(&{
         let mut bytes = [0u8; 16];
         rand::thread_rng().fill_bytes(&mut bytes);
-        hex::encode(&bytes)
+        hex::encode(bytes)
     });
     temp_dir.as_ref().join(&temp_filename)
 }
@@ -239,7 +239,7 @@ mod tests {
         fs::remove_file(&p)?;
         let (n_success, n_fail) = (1, n_total - 1);
         // Test that we see exactly one success and the rest as failures.
-        assert_eq!((n_success * 1) + (n_fail * -1), result);
+        assert_eq!(n_success + -n_fail, result);
 
         Ok(())
     }

--- a/src/bin/elfshaker/clone.rs
+++ b/src/bin/elfshaker/clone.rs
@@ -21,7 +21,7 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
 
     let original_cwd = std::env::current_dir()?;
     if Path::new(directory).exists() {
-        return Err(format!("'{}' already exists!", directory).into());
+        return Err(format!("'{directory}' already exists!").into());
     }
 
     let temp_directory = PathBuf::from(format!(
@@ -52,7 +52,7 @@ fn do_clone(work_dir: &Path, data_dir: &Path, origin_url: &str) -> Result<(), Bo
     fs::create_dir(work_dir)?;
     fs::create_dir_all(&data_dir)?;
 
-    let mut repo = Repository::open_with_data_dir(&work_dir, &data_dir)?;
+    let mut repo = Repository::open_with_data_dir(work_dir, &data_dir)?;
 
     repo.set_progress_reporter(|msg| create_percentage_print_reporter(msg, 5));
     repo.add_remote("origin", origin_url)?;
@@ -80,5 +80,5 @@ pub(crate) fn get_app() -> App<'static, 'static> {
 fn create_random_name() -> String {
     let mut bytes = [0u8; 8];
     rand::thread_rng().fill_bytes(&mut bytes);
-    hex::encode(&bytes)
+    hex::encode(bytes)
 }

--- a/src/bin/elfshaker/extract.rs
+++ b/src/bin/elfshaker/extract.rs
@@ -67,7 +67,7 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
     eprintln!("A \t{} files", result.added_file_count);
     eprintln!("D \t{} files", result.removed_file_count);
     eprintln!("M \t{} files", result.modified_file_count);
-    eprintln!("Extracted '{}'", new_head);
+    eprintln!("Extracted '{new_head}'");
 
     Ok(())
 }

--- a/src/bin/elfshaker/gc.rs
+++ b/src/bin/elfshaker/gc.rs
@@ -49,7 +49,7 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
             freed_bytes += repo.get_pack_disk_stats(&loose_pack)?.len;
 
             let PackId::Pack(ref name) = &loose_pack;
-            println!("Deleting pack {:?}", name);
+            println!("Deleting pack {name:?}");
 
             // Delete if requested
             if !dry_run {

--- a/src/bin/elfshaker/list.rs
+++ b/src/bin/elfshaker/list.rs
@@ -63,7 +63,7 @@ fn format_snapshot_row(
     file_count: usize,
 ) -> String {
     fmt.to_owned()
-        .replace("%s", &format!("{}:{}", pack_id, snapshot))
+        .replace("%s", &format!("{pack_id}:{snapshot}"))
         .replace("%t", snapshot)
         .replace("%h", &format_size(size))
         .replace("%b", &size.to_string())
@@ -92,7 +92,7 @@ fn print_snapshots(
                     pack_id,
                     snapshot,
                     file_size,
-                    file_count as usize,
+                    file_count,
                 ));
                 ControlFlow::<(), ()>::Continue(())
             };
@@ -122,7 +122,7 @@ fn print_snapshots(
     lines.sort();
 
     for line in lines {
-        println!("{}", line);
+        println!("{line}");
     }
 
     Ok(())

--- a/src/bin/elfshaker/list.rs
+++ b/src/bin/elfshaker/list.rs
@@ -88,11 +88,7 @@ fn print_snapshots(
             let mut pack_lines = vec![];
             let mut iter = |snapshot, file_size, file_count| {
                 pack_lines.push(format_snapshot_row(
-                    fmt,
-                    pack_id,
-                    snapshot,
-                    file_size,
-                    file_count,
+                    fmt, pack_id, snapshot, file_size, file_count,
                 ));
                 ControlFlow::<(), ()>::Continue(())
             };

--- a/src/bin/elfshaker/list_files.rs
+++ b/src/bin/elfshaker/list_files.rs
@@ -55,7 +55,7 @@ pub(crate) fn get_app() -> App<'static, 'static> {
 
 fn format_file_row(fmt: &str, checksum: &ObjectChecksum, file_name: &OsStr, size: u64) -> String {
     fmt.to_owned()
-        .replace("%o", &hex::encode(&checksum))
+        .replace("%o", &hex::encode(checksum))
         .replace("%f", &file_name.to_string_lossy())
         .replace("%h", &format_size(size))
         .replace("%b", &size.to_string())
@@ -80,7 +80,7 @@ fn print_files(
     lines.sort();
 
     for line in lines {
-        println!("{}", line);
+        println!("{line}");
     }
 
     Ok(())

--- a/src/bin/elfshaker/list_packs.rs
+++ b/src/bin/elfshaker/list_packs.rs
@@ -43,7 +43,7 @@ pub(crate) fn get_app() -> App<'static, 'static> {
 
 fn format_pack_row(fmt: &str, pack_id: &PackId, snapshot_count: usize, size: u64) -> String {
     fmt.to_owned()
-        .replace("%p", &format!("{}", pack_id))
+        .replace("%p", &format!("{pack_id}"))
         .replace("%c", &snapshot_count.to_string())
         .replace("%b", &size.to_string())
         .replace("%h", &format_size(size))
@@ -64,7 +64,7 @@ fn print_packs(repo: &Repository, fmt: &str) -> Result<(), Box<dyn Error>> {
     lines.sort();
 
     for line in lines {
-        println!("{}", line);
+        println!("{line}");
     }
 
     Ok(())

--- a/src/bin/elfshaker/pack.rs
+++ b/src/bin/elfshaker/pack.rs
@@ -165,7 +165,7 @@ fn packs_from_list(
         .map(|s| match s {
             Ok(v) => repo.find_snapshot(v).map(|l| l.pack().clone()),
             Err(e) => {
-                let msg = format!("Unable to decode snapshot list: {}", e);
+                let msg = format!("Unable to decode snapshot list: {e}");
                 Err(elfshaker::repo::Error::IOError(io::Error::new(
                     io::ErrorKind::InvalidData,
                     msg,

--- a/src/bin/elfshaker/show.rs
+++ b/src/bin/elfshaker/show.rs
@@ -45,7 +45,7 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
     let temp_dir = {
         let mut bytes = [0u8; 32];
         rand::thread_rng().fill_bytes(&mut bytes);
-        hex::encode(&bytes)
+        hex::encode(bytes)
     };
     let temp_dir = std::env::temp_dir().join(temp_dir);
 

--- a/src/bin/elfshaker/store.rs
+++ b/src/bin/elfshaker/store.rs
@@ -17,7 +17,7 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
     let files0_from = matches.value_of("files0-from");
     let snapshot = matches.value_of("snapshot").unwrap();
     // Use snapshot name as pack name.
-    let pack_id = PathBuf::from(format!("loose/{}", snapshot));
+    let pack_id = PathBuf::from(format!("loose/{snapshot}"));
     let pack_id = PackId::Pack(pack_id.to_str().unwrap().to_owned());
     let snapshot = SnapshotId::new(pack_id, snapshot)?;
 

--- a/src/bin/elfshaker/utils.rs
+++ b/src/bin/elfshaker/utils.rs
@@ -48,7 +48,7 @@ where
 {
     let format = |row: C| {
         row.into_iter()
-            .map(|item| format!("{}", item))
+            .map(|item| format!("{item}"))
             .collect::<Vec<_>>()
     };
     let header_strings = header.map(format);
@@ -57,7 +57,7 @@ where
     if strings.is_empty() {
         if let Some(header) = header_strings {
             for item in header.iter() {
-                eprint!("{} ", item);
+                eprint!("{item} ");
             }
             eprintln!();
         }
@@ -228,7 +228,7 @@ pub fn create_percentage_print_reporter(message: &str, step: u32) -> ProgressRep
                     );
                     // Optional "detail" message
                     if let Some(detail) = &checkpoint.detail {
-                        print!(": {}", detail);
+                        print!(": {detail}");
                     }
                 }
                 std::io::stdout().flush().unwrap();

--- a/src/packidx.rs
+++ b/src/packidx.rs
@@ -50,12 +50,11 @@ impl std::fmt::Display for PackError {
                 "Expected a complete file list, but got the delta format instead!"
             ),
             PackError::ObjectNotFound => write!(f, "The object was not found!"),
-            PackError::PathNotFound(p) => write!(f, "Corrupt pack, PathHandle {:?} not found", p),
-            PackError::SnapshotNotFound(s) => write!(f, "The snapshot '{}' was not found!", s),
+            PackError::PathNotFound(p) => write!(f, "Corrupt pack, PathHandle {p:?} not found"),
+            PackError::SnapshotNotFound(s) => write!(f, "The snapshot '{s}' was not found!"),
             PackError::SnapshotAlreadyExists(p, s) => write!(
                 f,
-                "A snapshot with the tag '{}' is already present in the pack '{}'!",
-                s, p,
+                "A snapshot with the tag '{s}' is already present in the pack '{p}'!",
             ),
             PackError::ChecksumMismatch(exp, got) => write!(
                 f,
@@ -63,18 +62,17 @@ impl std::fmt::Display for PackError {
                 hex::encode(exp),
                 hex::encode(got)
             ),
-            PackError::IOError(e) => write!(f, "Reading pack index: {}", e),
+            PackError::IOError(e) => write!(f, "Reading pack index: {e}"),
             PackError::DeserializeError(e) => {
-                write!(f, "Deserialization failed, corrupt pack index: {}", e)
+                write!(f, "Deserialization failed, corrupt pack index: {e}")
             }
             PackError::SerializeError(e) => {
-                write!(f, "Serialization failed: {}", e)
+                write!(f, "Serialization failed: {e}")
             }
             PackError::BadMagic => write!(f, "Bad pack magic, expected ELFS!"),
             PackError::BadPackVersion(v) => write!(
                 f,
-                "Pack version is too recent ({:?}), please upgrade elfshaker!",
-                v
+                "Pack version is too recent ({v:?}), please upgrade elfshaker!"
             ),
         }
     }
@@ -577,7 +575,7 @@ impl PackIndex {
     fn read_magic(rd: &mut impl Read) -> Result<(), PackError> {
         let mut magic = [0; 4];
         rd.read_exact(&mut magic)?;
-        if magic.ne(&*b"ELFS") {
+        if magic.ne(b"ELFS") {
             return Err(PackError::BadMagic);
         }
         let mut version = [0; 4];
@@ -589,7 +587,7 @@ impl PackIndex {
     }
 
     fn write_magic(wr: &mut impl Write) -> std::io::Result<()> {
-        wr.write_all(&*b"ELFS")?;
+        wr.write_all(b"ELFS")?;
         wr.write_all(&[0, 0, 0, 1])?;
         Ok(())
     }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -9,8 +9,10 @@ pub struct Checkpoint {
     pub detail: Option<String>,
 }
 
+type CallbackFn<'a> = Option<Box<dyn Fn(&Checkpoint) + Sync + 'a>>;
+
 pub struct ProgressReporter<'a> {
-    callback: Option<Box<dyn Fn(&Checkpoint) + Sync + 'a>>,
+    callback: CallbackFn<'a>,
 }
 
 unsafe impl<'a> Send for ProgressReporter<'a> {}

--- a/src/repo/error.rs
+++ b/src/repo/error.rs
@@ -59,9 +59,9 @@ impl Display for Error {
             Self::PackError(packerr) => packerr.fmt(f),
             Self::IdError(iderr) => iderr.fmt(f),
             Self::WalkDirError(wderr) => wderr.fmt(f),
-            Self::Utf8Error(s) => write!(f, "Unable to interpret path as utf8: {:?}", s),
+            Self::Utf8Error(s) => write!(f, "Unable to interpret path as utf8: {s:?}"),
             Self::CorruptHead => write!(f, "HEAD is corrupt!"),
-            Self::BrokenHeadRef(e) => write!(f, "Broken HEAD: {}", e),
+            Self::BrokenHeadRef(e) => write!(f, "Broken HEAD: {e}"),
             Self::CorruptPack => {
                 write!(f, "The pack file is corrupt!")
             }
@@ -69,8 +69,7 @@ impl Display for Error {
             Self::AmbiguousSnapshotMatch(snapshot, packs) => {
                 write!(
                     f,
-                    "The requested snapshot {} lives in multiple packs: {:?}",
-                    snapshot, packs
+                    "The requested snapshot {snapshot} lives in multiple packs: {packs:?}"
                 )
             }
             Self::DirtyWorkDir => write!(
@@ -80,11 +79,10 @@ impl Display for Error {
             ),
             Self::PackNotFound(p) => write!(
                 f,
-                "The specified pack file '{}' could not be found in the repository index!",
-                p,
+                "The specified pack file '{p}' could not be found in the repository index!",
             ),
             Self::RepositoryNotFound => write!(f, "The directory is not an elfshaker repository!"),
-            Self::BadLooseObject(s) => write!(f, "Bad loose object: {}", s),
+            Self::BadLooseObject(s) => write!(f, "Bad loose object: {s}"),
             Self::HttpError(e) => e.fmt(f),
             Self::BadRemoteIndexFormat(e) => e.fmt(f),
         }

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -27,7 +27,7 @@ pub fn get_last_modified(metadata: fs::Metadata) -> Option<SystemTime> {
 /// Ensures that the directory exists.
 /// Unlike [`fs::create_dir()`], this function does not return Err if the directory already exists.
 pub fn ensure_dir(path: &Path) -> io::Result<()> {
-    match fs::create_dir_all(&path) {
+    match fs::create_dir_all(path) {
         Ok(_) => Ok(()),
         Err(ref e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
         Err(e) => Err(e),
@@ -57,7 +57,7 @@ pub fn create_temp_path(temp_dir: &Path) -> PathBuf {
     let temp_filename = {
         let mut bytes = [0u8; 16];
         rand::thread_rng().fill_bytes(&mut bytes);
-        hex::encode(&bytes)
+        hex::encode(bytes)
     };
     temp_dir.join(temp_filename)
 }
@@ -271,7 +271,7 @@ mod tests {
         let file = leaf_dir.join("file");
 
         fs::create_dir_all(&leaf_dir)?;
-        fs::write(&file, &[])?;
+        fs::write(&file, [])?;
 
         remove_empty_dirs(&leaf_dir, &boundary_dir)?;
 

--- a/src/repo/pack.rs
+++ b/src/repo/pack.rs
@@ -42,16 +42,14 @@ pub enum IdError {
 impl Display for IdError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Self::BadFormat(s) => write!(f, "Unrecognized identifier format '{}'!", s),
+            Self::BadFormat(s) => write!(f, "Unrecognized identifier format '{s}'!"),
             Self::InvalidPack(s) => write!(
                 f,
-                "Invalid pack identifier '{}'! Latin letters, digits, -, _ and / are allowed!",
-                s
+                "Invalid pack identifier '{s}'! Latin letters, digits, -, _ and / are allowed!"
             ),
             Self::InvalidSnapshot(s) => write!(
                 f,
-                "Invalid snapshot identifier '{}'! Latin letters, digits, - and _ are allowed!",
-                s
+                "Invalid snapshot identifier '{s}'! Latin letters, digits, - and _ are allowed!"
             ),
         }
     }
@@ -94,7 +92,7 @@ impl FromStr for PackId {
 impl Display for PackId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            PackId::Pack(s) => write!(f, "{}", s),
+            PackId::Pack(s) => write!(f, "{s}"),
         }
     }
 }
@@ -317,7 +315,7 @@ impl Pack {
 
     /// Opens the pack file for reading.
     fn open_pack(pack_path: &Path) -> Result<(u64, PackHeader, Vec<PackReader>), Error> {
-        let file = open_file(&pack_path)?;
+        let file = open_file(pack_path)?;
         let file_size = file.metadata()?.len();
         let mut reader = io::BufReader::new(file);
 
@@ -336,7 +334,7 @@ impl Pack {
         let frame_readers = frame_offsets
             .iter()
             .map(|offset| -> Result<_, Error> {
-                let mut reader = open_file(&pack_path)?;
+                let mut reader = open_file(pack_path)?;
                 io::Seek::seek(&mut reader, io::SeekFrom::Start(header_size + offset))?;
                 let mut reader = Decoder::new(reader)?;
                 reader.set_parameter(DParameter::WindowLogMax(DEFAULT_WINDOW_LOG_MAX))?;
@@ -351,7 +349,7 @@ impl Pack {
 
     /// Backwards-compatible open_pack for the legacy pack format (no skippable frame/no header).
     fn open_pack_legacy(pack_path: &Path) -> Result<(u64, PackHeader, Vec<PackReader>), Error> {
-        let file = open_file(&pack_path)?;
+        let file = open_file(pack_path)?;
         let file_size = file.metadata()?.len();
 
         // This manufactured pack header works for the current implementation. We might

--- a/src/repo/remote.rs
+++ b/src/repo/remote.rs
@@ -378,9 +378,7 @@ pub fn update_remote_pack(
     pack_path: &Path,
     reporter: &ProgressReporter,
 ) -> Result<(), Error> {
-    let date_modified = fs::metadata(pack_path)
-        .ok()
-        .and_then(|x| x.modified().ok());
+    let date_modified = fs::metadata(pack_path).ok().and_then(|x| x.modified().ok());
 
     let url = remote_pack.url.parse::<Url>().unwrap();
     if let Some((content_length, mut reader)) =


### PR DESCRIPTION
I've been doing a bit of elfshaker hacking recently. Let's get the nitty/straightforward stuff out of the way first since it otherwise gets in the way of development by making you revisit warnings.

As a note, I'm developing with Cargo stable, which is 1.67.0; I haven't tested older versions to see what the eldest we can support is. For now I'm thinking so long as we don't depend on something 'more recent than stable at a given moment', this is a reasonable thing to do, but the included nix changes also make it straightforward to test different rust versions if we want to figure out what the eldest we support is at some point.

In this PR:

* Run `cargo update`. I've not dug in here as much as I would like but it looks mostly straightforward. It looks like some of our dependencies added dependencies.
* Run `clippy --fix` and manually fix one minor issue (complex type).
* Run `cargo fmt`.
* Add a nix flake for development/building.
  * I find the nix flake convenient for development. It gives me an environment for building musl binaries for different architectures straightforwardly; I'm also able to build windows and x86 binaries but that will come in a later commit. I intend to include more nix recipes in this repo in the near future, including a recipe for building standalone clang. I also intend to automate the release mechanism using nix, that is, it will upload binaries built using it via github actions to the release page, so that we can produce the same kind of binaries for our different supported platforms.