### PR TITLE
Preserve File Modes

### DIFF
--- a/src/bin/elfshaker/list.rs
+++ b/src/bin/elfshaker/list.rs
@@ -96,7 +96,7 @@ fn print_snapshots(
             if is_file_size_required(fmt) {
                 index.for_each_snapshot(|snapshot, entries| {
                     let file_count = entries.len();
-                    let file_size = entries.iter().map(|entry| entry.metadata.size).sum();
+                    let file_size = entries.iter().map(|entry| entry.object_metadata.size).sum();
                     iter(snapshot, file_size, file_count)
                 })?;
             } else {

--- a/src/bin/elfshaker/list_files.rs
+++ b/src/bin/elfshaker/list_files.rs
@@ -48,17 +48,25 @@ pub(crate) fn get_app() -> App<'static, 'static> {
                     \t%o - file checksum\n\
                     \t%f - file name\n\
                     \t%h - human-readable size\n\
-                    \t%b - size in bytes\n",
+                    \t%b - size in bytes\n\
+                    \t%p - permissions",
                 ),
         )
 }
 
-fn format_file_row(fmt: &str, checksum: &ObjectChecksum, file_name: &OsStr, size: u64) -> String {
+fn format_file_row(
+    fmt: &str,
+    checksum: &ObjectChecksum,
+    file_name: &OsStr,
+    size: u64,
+    file_mode: u32,
+) -> String {
     fmt.to_owned()
         .replace("%o", &hex::encode(checksum))
         .replace("%f", &file_name.to_string_lossy())
         .replace("%h", &format_size(size))
         .replace("%b", &size.to_string())
+        .replace("%p", &format!("{:o}", file_mode))
 }
 
 fn print_files(
@@ -80,6 +88,7 @@ fn print_files(
                 &entry.checksum,
                 &entry.path,
                 entry.object_metadata.size,
+                entry.file_metadata.mode,
             )
         })
         .collect();

--- a/src/bin/elfshaker/list_files.rs
+++ b/src/bin/elfshaker/list_files.rs
@@ -74,7 +74,14 @@ fn print_files(
     let mut lines: Vec<_> = index
         .entries_from_handles(handles.iter())?
         .into_iter()
-        .map(|entry| format_file_row(fmt, &entry.checksum, &entry.path, entry.metadata.size))
+        .map(|entry| {
+            format_file_row(
+                fmt,
+                &entry.checksum,
+                &entry.path,
+                entry.object_metadata.size,
+            )
+        })
         .collect();
 
     lines.sort();

--- a/src/packidx.rs
+++ b/src/packidx.rs
@@ -561,6 +561,7 @@ impl PackIndex {
         let mut hasher = entries.into_iter().fold(Sha1::new(), |mut hasher, entry| {
             hasher.input(&os_str_as_bytes(entry.path));
             hasher.input(entry.checksum);
+            hasher.input(&entry.file_metadata.mode.to_be_bytes());
             hasher
         });
         let mut checksum: ObjectChecksum = [0; 20];

--- a/src/packidx.rs
+++ b/src/packidx.rs
@@ -121,12 +121,18 @@ pub struct FileHandle {
 }
 
 #[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-pub struct FileMetadata {}
+pub struct FileMetadata {
+    pub mode: u32,
+}
 
 /// Format version 1 packs will use a default file metadata.
 impl Default for FileMetadata {
     fn default() -> Self {
-        Self {}
+        Self {
+            // The default mode bits are owner can rw, everyone else can read,
+            // which is the same behaviour as in version 1 of the pack format.
+            mode: 0o100664,
+        }
     }
 }
 

--- a/src/packidx.rs
+++ b/src/packidx.rs
@@ -564,7 +564,7 @@ impl PackIndex {
 
     pub fn save<P: AsRef<Path>>(&self, p: P) -> Result<(), PackError> {
         // TODO: Use AtomicCreateFile.
-        let wr = create_file(p.as_ref())?;
+        let wr = create_file(p.as_ref(), None)?;
         let mut wr = BufWriter::new(wr);
         Self::write_magic(&mut wr)?;
 

--- a/src/repo/pack.rs
+++ b/src/repo/pack.rs
@@ -3,8 +3,9 @@
 
 use serde::{Deserialize, Serialize};
 use std::{
-    fmt, fs,
+    fmt,
     fs::File,
+    fs::{self, Permissions},
     io,
     io::{BufReader, Read, Write},
     path::{Path, PathBuf},
@@ -491,9 +492,9 @@ fn verify_object(buf: &[u8], exp_checksum: &ObjectChecksum) -> Result<(), Error>
 
 /// Writes the object to the specified path, taking care
 /// of adjusting file permissions.
-fn write_object(buf: &[u8], path: &Path) -> Result<(), Error> {
+fn write_object(buf: &[u8], path: &Path, perm: Option<Permissions>) -> Result<(), Error> {
     fs::create_dir_all(path.parent().unwrap())?;
-    let mut f = create_file(path)?;
+    let mut f = create_file(path, perm)?;
     f.write_all(buf)?;
     Ok(())
 }
@@ -660,7 +661,7 @@ fn extract_files(
             path_buf.clear();
             path_buf.push(&output_dir);
             path_buf.push(&entry.path);
-            stats.write_time += measure_ok(|| write_object(&buf[..], &path_buf))?
+            stats.write_time += measure_ok(|| write_object(&buf[..], &path_buf, None))?
                 .0
                 .as_secs_f64();
         }

--- a/src/repo/pack.rs
+++ b/src/repo/pack.rs
@@ -549,6 +549,7 @@ fn assign_to_frames(
                 offset: local_offset, // Replace global offset -> local offset
                 size: entry.object_metadata.size,
             },
+            Default::default(),
         );
         frames[frame_index].push(local_entry);
     }
@@ -721,8 +722,8 @@ mod tests {
             decompressed_size: 1000,
         }];
         let entries = [
-            FileEntry::new("A".into(), [0; 20], make_md(50, 1)),
-            FileEntry::new("B".into(), [1; 20], make_md(50, 1)),
+            FileEntry::new("A".into(), [0; 20], make_md(50, 1), Default::default()),
+            FileEntry::new("B".into(), [1; 20], make_md(50, 1), Default::default()),
         ];
         let result = assign_to_frames(&frames, &entries).unwrap();
         assert_eq!(1, result.len());
@@ -741,16 +742,16 @@ mod tests {
             },
         ];
         let entries = [
-            FileEntry::new("A".into(), [0; 20], make_md(800, 200)),
-            FileEntry::new("B".into(), [1; 20], make_md(1200, 200)),
+            FileEntry::new("A".into(), [0; 20], make_md(800, 200), Default::default()),
+            FileEntry::new("B".into(), [1; 20], make_md(1200, 200), Default::default()),
         ];
         let frame_1_entries = [
             // Offset is same
-            FileEntry::new("A".into(), [0; 20], make_md(800, 200)),
+            FileEntry::new("A".into(), [0; 20], make_md(800, 200), Default::default()),
         ];
         let frame_2_entries = [
             // Offset 1200 -> 200
-            FileEntry::new("B".into(), [1; 20], make_md(200, 200)),
+            FileEntry::new("B".into(), [1; 20], make_md(200, 200), Default::default()),
         ];
         let result = assign_to_frames(&frames, &entries).unwrap();
         assert_eq!(2, result.len());

--- a/src/repo/remote.rs
+++ b/src/repo/remote.rs
@@ -395,7 +395,7 @@ pub fn update_remote_pack(
         hasher.result(&mut checksum);
 
         if checksum == remote_pack.pack_checksum {
-            create_file(pack_path)?.write_all(&data)?;
+            create_file(pack_path, None)?.write_all(&data)?;
         } else {
             log::error!(
                 "The pack checksum did not match the one in the .esi! The download failed."
@@ -477,7 +477,7 @@ pub fn fetch_remote(agent: &Agent, url: &str, path: &Path) -> Result<RemoteIndex
         Some(data) => {
             let mut remote = RemoteIndex::read(BufReader::new(data.as_slice())).reify(url)?;
             // Update the .esi
-            create_file(path)
+            create_file(path, None)
                 .map_err(Error::IOError)?
                 .write_all(data.as_slice())
                 .map_err(Error::IOError)?;
@@ -507,7 +507,7 @@ pub fn update_remote(agent: &Agent, remote: &RemoteIndex) -> Result<RemoteIndex,
         Some(data) => {
             let mut remote = RemoteIndex::read(BufReader::new(data.as_slice())).reify(url)?;
             // Update the .esi
-            create_file(path)
+            create_file(path, None)
                 .map_err(Error::IOError)?
                 .write_all(data.as_slice())
                 .map_err(Error::IOError)?;

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -584,10 +584,12 @@ impl Repository {
 
         let pack_entries = run_in_parallel(threads, files.into_iter(), |file_path| {
             let mut fd = File::open(&file_path)?;
-            let mut buf = vec![];
-            fd.read_to_end(&mut buf)?;
-            let mode = fd.metadata()?.permissions().mode();
-            drop(fd);
+            let (buf, mode) = {
+                let mut buf = vec![];
+                fd.read_to_end(&mut buf)?;
+                let mode = fd.metadata()?.permissions().mode();
+                (buf, mode)
+            };
             let mut checksum = [0u8; 20];
             let mut hasher = Sha1::new();
             hasher.input(&buf);

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -717,7 +717,7 @@ impl Repository {
         let header_bytes = rmp_serde::encode::to_vec(&header).expect("Serialization failed!");
 
         // And a writer to that temporary file.
-        let mut pack_writer = io::BufWriter::new(create_file(&temp_path)?);
+        let mut pack_writer = io::BufWriter::new(create_file(&temp_path, None)?);
         // Write header and frames.
         write_skippable_frame(&mut pack_writer, &header_bytes)?;
         for frame_buf in frame_bufs {

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -595,6 +595,7 @@ impl Repository {
                     offset: LOOSE_OBJECT_OFFSET,
                     size: buf.len() as u64,
                 },
+                Default::default(),
             ))
         })
         .into_iter()
@@ -1344,8 +1345,18 @@ mod tests {
         let path = "/path/to/A";
         let old_checksum = [0; 20];
         let new_checksum = [1; 20];
-        let old_entries = [FileEntry::new(path.into(), old_checksum, EXAMPLE_MD)];
-        let new_entries = [FileEntry::new(path.into(), new_checksum, EXAMPLE_MD)];
+        let old_entries = [FileEntry::new(
+            path.into(),
+            old_checksum,
+            EXAMPLE_MD,
+            Default::default(),
+        )];
+        let new_entries = [FileEntry::new(
+            path.into(),
+            new_checksum,
+            EXAMPLE_MD,
+            Default::default(),
+        )];
         let (added, removed) = Repository::compute_entry_diff(&old_entries, &new_entries);
         assert_eq!(1, added.len());
         assert_eq!(path, added[0].path);
@@ -1361,13 +1372,24 @@ mod tests {
         let path_b_old_checksum = [0; 20];
         let path_a_new_checksum = [1; 20];
         let old_entries = [
-            FileEntry::new(path_a.into(), path_a_old_checksum, EXAMPLE_MD),
-            FileEntry::new(path_b.into(), path_b_old_checksum, EXAMPLE_MD),
+            FileEntry::new(
+                path_a.into(),
+                path_a_old_checksum,
+                EXAMPLE_MD,
+                Default::default(),
+            ),
+            FileEntry::new(
+                path_b.into(),
+                path_b_old_checksum,
+                EXAMPLE_MD,
+                Default::default(),
+            ),
         ];
         let new_entries = [FileEntry::new(
             path_a.into(),
             path_a_new_checksum,
             EXAMPLE_MD,
+            Default::default(),
         )];
         let (added, removed) = Repository::compute_entry_diff(&old_entries, &new_entries);
         assert_eq!(1, added.len());
@@ -1386,12 +1408,32 @@ mod tests {
         let path_b_old_checksum = [1; 20];
         let path_b_new_checksum = [0; 20];
         let old_entries = [
-            FileEntry::new(path_a.into(), path_a_old_checksum, EXAMPLE_MD),
-            FileEntry::new(path_b.into(), path_b_old_checksum, EXAMPLE_MD),
+            FileEntry::new(
+                path_a.into(),
+                path_a_old_checksum,
+                EXAMPLE_MD,
+                Default::default(),
+            ),
+            FileEntry::new(
+                path_b.into(),
+                path_b_old_checksum,
+                EXAMPLE_MD,
+                Default::default(),
+            ),
         ];
         let new_entries = [
-            FileEntry::new(path_a.into(), path_a_new_checksum, EXAMPLE_MD),
-            FileEntry::new(path_b.into(), path_b_new_checksum, EXAMPLE_MD),
+            FileEntry::new(
+                path_a.into(),
+                path_a_new_checksum,
+                EXAMPLE_MD,
+                Default::default(),
+            ),
+            FileEntry::new(
+                path_b.into(),
+                path_b_new_checksum,
+                EXAMPLE_MD,
+                Default::default(),
+            ),
         ];
         let (added, removed) = Repository::compute_entry_diff(&old_entries, &new_entries);
         assert_eq!(2, added.len());

--- a/test-scripts/check.sh
+++ b/test-scripts/check.sh
@@ -116,7 +116,7 @@ serve_file_http() {
   port=$1
   file="$2"
   content_length="$(wc -c <"$file")"
-  (printf "HTTP/1.1 200 OK\r\nContent-Length: $content_length\r\n\r\n"; cat "$file") | nc -l -p $port
+  (printf "HTTP/1.1 200 OK\r\nContent-Length: $content_length\r\n\r\n"; cat "$file") | nc -l $port
 }
 
 # TESTS

--- a/test-scripts/check.sh
+++ b/test-scripts/check.sh
@@ -450,7 +450,7 @@ test_head_updated_after_packing() {
 
 test_touched_file_dirties_repo() {
   "$elfshaker" extract --verify --reset "$pack":"$snapshot_a"
-  find . -not -path "./elfshaker_data/*" -exec touch -d "$(date --date='now +10 sec')" {} +
+  find . -not -path "./elfshaker_data/*" -exec touch -d "$(date -R --date='now +10 sec')" {} +
   if "$elfshaker" extract --verbose --verify "$pack":"$snapshot_b"; then
     echo 'Failed to detect files changes!'
     exit 1
@@ -459,7 +459,7 @@ test_touched_file_dirties_repo() {
 
 test_dirty_repo_can_be_forced() {
   "$elfshaker" extract --verify --reset "$pack":"$snapshot_a"
-  find . -not -path "./elfshaker_data/*" -exec touch -d "$(date --date='now +10 sec')" {} +
+  find . -not -path "./elfshaker_data/*" -exec touch -d "$(date -R --date='now +10 sec')" {} +
   if ! "$elfshaker" extract --verbose --force --verify "$pack":"$snapshot_b"; then
     echo 'Could not use --force to skip dirty repository checks!'
     exit 1


### PR DESCRIPTION
Add a notion of FileMetadata (describing file state), as distinct from
ObjectMetadata (which describes objects in the store) which is stored in
the FileHandle and therefore on disk as part of snapshot_deltas.
FileMetadata is intended to be extensible but in the first instance
describes file modes bits. In the future it may also describe mtime and
I can imagine further uses arising.

[Note, I've edited this body to reflect the new approach, much of it
remains true from before and stays the same]

Users of the main branch, please note I forsee further potential version
bumps for additional functionality in the near future. If you're using
elfshaker in anger to make long term packs you may want to hold off
making those packs so you get the extra benefits, though it should work
aside from the missing as-yet-unimplemented features.

Compatibility notes:

* This elfshaker commit will still be able to read old elfshaker pack
  index files, because the default of an optional is None, which gives
  us exactly the old behaviour of elfshaker prior to this commit.

* elfshaker after this commit will produce packfiles that cannot be read
  by older commits of elfshaker. However, those old versions will report
  to the user that the version they have is too old and point them to
  where they can obtain a newer version.

The biggest risk here is that someone using the main branch makes
packfiles, and distributes those packfiles to a user who is not able to
build elfshaker, and we have not yet gotten around to releasing a new
version of elfshaker. So we should aim for a release of a new version
reasonably soon so that users don't find themselves in this situation
where they can't get an elfshaker which can read the packfiles they have
been provided.

Using an old elfshaker to produce packfiles and ship them to users of
any version of elfshaker is intended to be supported in principle.

Implementation:

We make use of the fact that a default `Option` is `None`, and that
Serde deserializers can cope with missing fields at the end of a struct
with the default attribute. Therefore to make elfshaker able to read old
files while implementing the new field, it's only necessary to add
`#[serde(default)]`.

The version bump ensures that users of an old elfshaker trying to read a
pack written with the newer elfshaker see an informative message rather
than a deserialization failure.

Review notes:

Please see the individual commits which should make it reasonably clear how this works.

### TODO

- [x] Write additional tests. I intend to do this before merging, so
    please consider this draft until then. Feel free to take an early
    look or defer your look until I declare this ready.
  - [x] Check that file modes changing across snapshots has the correct effect; I recall there being a potential gotcha here that changes in metadata without changes in content might be a problem. I'll need to look into that.