### PR TITLE
Slightly clarify what a snapshot is in usage.md [doc] [fix typo]

### DIFF
--- a/docs/users/usage.md
+++ b/docs/users/usage.md
@@ -20,7 +20,7 @@
 **Important: Understanding of the following concepts is critical to working with the tool.**
 
 - Snapshot
-    - Store a directory state (a set of files)
+    - Stores a directory state (a set of files)
     - Created by `elfshaker store`
     - Can be packed into a pack file by `elfshaker pack` (otherwise called a loose snapshot)
 - Repository


### PR DESCRIPTION
Grammatically, "A snapshot stores a directory state" is more correct than "A snapshot store a directory state". This matters because, with the current wording, it is easier to mistakenly interpret "Snapshot" as a verb instead of a noun in this context.