### PR TITLE
Add release machinery

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -6,7 +6,7 @@ jobs:
   clippy_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - run: cargo fmt --all -- --check
       - run: rustup component add clippy
       - uses: actions-rs/clippy-check@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build
       run: cargo build --release --verbose
     - name: Run tests

--- a/.github/workflows/test-nix.yml
+++ b/.github/workflows/test-nix.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: docker/setup-qemu-action@v2
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: docker/setup-qemu-action@v2
       - name: Build
         run: nix build .#release
       - name: ls
         run: ls -la result/
 
-  build-macos:
+  build-macos-x86_64:
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-nix.yml
+++ b/.github/workflows/test-nix.yml
@@ -1,0 +1,31 @@
+name: Testing Nix
+
+on:
+  push:
+    branches: [ main test-ci ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Build
+        run: nix build .#release
+      - name: ls
+        run: ls -la result/
+
+  build-macos:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Build
+        run: nix build .#release
+      - name: ls
+        run: ls -la result/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "elfshaker"
-version = "0.1.0"
+version = "1.0.0-rc1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "elfshaker"
-version = "0.1.0"
+version = "1.0.0-rc1"
 authors = ["Veselin Karaganev <veselin.karaganev@arm.com>", "Peter Waller <peter.waller@arm.com>"]
 edition = "2018"
 

--- a/elfshaker.nix
+++ b/elfshaker.nix
@@ -18,11 +18,7 @@ naerskBuildPackage target {
   name = "elfshaker-${stdenv.hostPlatform.config}";
   root = ./.;
 
-  # Check is broken on x86 musl with:
-  # >   = note: /nix/store/hjmy3kzf3cv15argfc10mgml1hbnyzph-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: /nix/store/cdaf8ha86l89d0nbfwhm42sg1q4jziic-x86_64-unknown-linux-musl-stage-final-gcc-12.2.0-lib/x86_64-unknown-linux-musl/lib/libstdc++.a(compatibility.o): relocation R_X86_64_32 against symbol `__gxx_personality_v0' can not be used when making a PIE object; recompi le with -fPIE
-  # >           /nix/store/hjmy3kzf3cv15argfc10mgml1hbnyzph-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: failed to set dynamic section sizes: bad value
-  doCheck = stdenv.hostPlatform.config != "x86_64-unknown-linux-musl";
-  # doCheck = true;
+  doCheck = true;
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/elfshaker.nix
+++ b/elfshaker.nix
@@ -15,6 +15,7 @@ let
 in
 
 naerskBuildPackage target {
+  name = "elfshaker-${stdenv.hostPlatform.config}";
   root = ./.;
 
   # Check is broken on x86 musl with:

--- a/elfshaker.nix
+++ b/elfshaker.nix
@@ -1,0 +1,41 @@
+{
+  naerskBuildPackage,
+  rustToolchain,
+  netcat,
+  removeReferencesTo,
+  stdenv,
+}:
+
+let
+  target =
+    if stdenv.hostPlatform.config == "x86_64-w64-mingw32"
+    # Rust spells the target differently.
+    then "x86_64-pc-windows-gnu"
+    else stdenv.hostPlatform.config;
+in
+
+naerskBuildPackage target {
+  root = ./.;
+
+  # Check is broken on x86 musl with:
+  # >   = note: /nix/store/hjmy3kzf3cv15argfc10mgml1hbnyzph-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: /nix/store/cdaf8ha86l89d0nbfwhm42sg1q4jziic-x86_64-unknown-linux-musl-stage-final-gcc-12.2.0-lib/x86_64-unknown-linux-musl/lib/libstdc++.a(compatibility.o): relocation R_X86_64_32 against symbol `__gxx_personality_v0' can not be used when making a PIE object; recompi le with -fPIE
+  # >           /nix/store/hjmy3kzf3cv15argfc10mgml1hbnyzph-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: failed to set dynamic section sizes: bad value
+  doCheck = stdenv.hostPlatform.config != "x86_64-unknown-linux-musl";
+  # doCheck = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    stdenv.cc
+    removeReferencesTo
+    netcat # For tests.
+    # TODO: Windows pthreads?
+  ];
+
+  postInstall = ''
+    echo "Removing references to $cratesio_sources"
+    remove-references-to -t $cratesio_sources $out/bin/elfshaker
+
+    echo "Testing elfshaker binary with check.sh"
+    $SHELL ${./.}/test-scripts/check.sh $out/bin/elfshaker ${./.}/test-scripts/artifacts/verification.pack
+  '';
+}

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1674800601,
-        "narHash": "sha256-25OW8RylGrcGFhf5swfQLNjKRH87ltuvNgccrGKlKZ8=",
+        "lastModified": 1692598848,
+        "narHash": "sha256-LYQNc486Em/UGU/LCzbcafNY6kOdl1mP6FcnWdudFKo=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "0a237d66ea3be2ae39fb4d279a4ae417bf38e2da",
+        "rev": "224c5c301ab5f96afe51ec4dfa661fa82ab4ad05",
         "type": "github"
       },
       "original": {
@@ -28,32 +28,31 @@
         ]
       },
       "locked": {
-        "lastModified": 1655042882,
-        "narHash": "sha256-9BX8Fuez5YJlN7cdPO63InoyBy7dm3VlJkkmTt6fS1A=",
+        "lastModified": 1692351612,
+        "narHash": "sha256-KTGonidcdaLadRnv9KFgwSMh1ZbXoR/OBmPjeNMhFwU=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "cddffb5aa211f50c4b8750adbec0bbbdfb26bb9f",
+        "rev": "78789c30d64dea2396c9da516bbcc8db3a475207",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "cddffb5aa211f50c4b8750adbec0bbbdfb26bb9f",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672580127,
-        "narHash": "sha256-3lW3xZslREhJogoOkjeZtlBtvFMyxHku7I/9IVehhT8=",
+        "lastModified": 1692447944,
+        "narHash": "sha256-fkJGNjEmTPvqBs215EQU4r9ivecV5Qge5cF/QDLVn3U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0874168639713f547c05947c76124f78441ea46c",
+        "rev": "d680ded26da5cf104dd2735a51e88d2d8f487b4d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-22.05",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -62,40 +61,23 @@
       "inputs": {
         "fenix": "fenix",
         "naersk": "naersk",
-        "nixpkgs": "nixpkgs",
-        "utils": "utils"
+        "nixpkgs": "nixpkgs"
       }
     },
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1674747430,
-        "narHash": "sha256-zXsp+LWyOZjjC3AjD1HXIntpnWuKnwdEaWI5zcSrBhc=",
+        "lastModified": 1692456871,
+        "narHash": "sha256-ribQkxEbMMb8vcBMKvcrPHFftMmlaF3HIAbJty9fDeY=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "9814d798411a4b1b258c710f86626bd1997e406f",
+        "rev": "83b3ba1b8191c065bb0dacc79e5896f7f21e4611",
         "type": "github"
       },
       "original": {
         "owner": "rust-lang",
         "ref": "nightly",
         "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -16,11 +16,16 @@
 
     devShell = forAllSystems (system: let
       pkgs = import nixpkgs { inherit system; };
-    in pkgs.mkShell {
-      nativeBuildInputs = [ self.packages.${system}.rustToolchain ];
+    in pkgs.mkShell (self.packages.${system}.elfshakerCargoConfig // {
+      nativeBuildInputs = [
+        self.packages.${system}.rustToolchain
+        pkgs.pkgsCross.aarch64-multiplatform-musl.stdenv.cc
+        pkgs.pkgsCross.musl64.stdenv.cc
+        pkgs.pkgsCross.mingwW64.stdenv.cc
+      ];
       CARGO_BUILD_TARGET = pkgs.stdenv.hostPlatform.config;
       NIX_PATH = "nixpkgs=${nixpkgs.outPath}";
-    });
+    }));
 
     packages = forAllSystems (system: let
       pkgs = import nixpkgs { inherit system; };
@@ -82,6 +87,7 @@
 
     in {
       inherit rustToolchain;
+      elfshakerCargoConfig = cargoConfig;
 
       # Native package build.
       default = packages.elfshaker;

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,18 @@
 
         CC_x86_64_unknown_linux_musl = "x86_64-unknown-linux-musl-gcc";
         CC_x86_64_unknown_linux_gnu = "cc";
-        CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS = "-L${pkgs.pkgsCross.musl64.pkgsStatic.stdenv.cc.cc.lib}/x86_64-unknown-linux-musl/lib -lstatic=stdc++ -C target-feature=+crt-static";
+        CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS = [
+          "-L${pkgs.pkgsCross.musl64.pkgsStatic.stdenv.cc.cc.lib}/x86_64-unknown-linux-musl/lib"
+          "-lstatic=stdc++"
+          "-Ctarget-feature=+crt-static"
+          # The default of static pie executables results in the error message:
+          # > x86_64-unknown-linux-musl-ld: gcc-12.2.0-lib/x86_64-unknown-linux-musl/lib/libstdc++.a(compatibility.o):
+          # >   relocation R_X86_64_32 against symbol `__gxx_personality_v0' can not be used when making a PIE object; recompile with -fPIE
+          # > x86_64-unknown-linux-musl-ld: failed to set dynamic section sizes: bad value
+          # ... But only in the test binary, presumably because it somehow ends
+          # up using the symbol in a problematic way.
+          "-Crelocation-model=pic"
+        ];
         CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = "x86_64-unknown-linux-musl-ld";
         CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER = "cc";
 

--- a/flake.nix
+++ b/flake.nix
@@ -57,24 +57,24 @@
       cargoConfig = lib.optionalAttrs pkgs.stdenv.isLinux {
         CC_aarch64_unknown_linux_musl = "aarch64-unknown-linux-musl-gcc";
         CC_aarch64_unknown_linux_gnu = "cc";
-        CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS = "-L${pkgs.pkgsCross.aarch64-multiplatform-musl.pkgsStatic.stdenv.cc.cc.lib}/aarch64-unknown-linux-musl/lib -lstatic=stdc++ -C target-feature=+crt-static -C link-arg=-lc";
+        # CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS = "-L${pkgs.pkgsCross.aarch64-multiplatform-musl.pkgsStatic.stdenv.cc.cc.lib}/aarch64-unknown-linux-musl/lib -lstatic=stdc++ -C target-feature=+crt-static -C link-arg=-lc";
         CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER = "aarch64-unknown-linux-musl-ld";
         CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER = "cc";
 
         CC_x86_64_unknown_linux_musl = "x86_64-unknown-linux-musl-gcc";
         CC_x86_64_unknown_linux_gnu = "cc";
-        CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS = [
-          "-L${pkgs.pkgsCross.musl64.pkgsStatic.stdenv.cc.cc.lib}/x86_64-unknown-linux-musl/lib"
-          "-lstatic=stdc++"
-          "-Ctarget-feature=+crt-static"
-          # The default of static pie executables results in the error message:
-          # > x86_64-unknown-linux-musl-ld: gcc-12.2.0-lib/x86_64-unknown-linux-musl/lib/libstdc++.a(compatibility.o):
-          # >   relocation R_X86_64_32 against symbol `__gxx_personality_v0' can not be used when making a PIE object; recompile with -fPIE
-          # > x86_64-unknown-linux-musl-ld: failed to set dynamic section sizes: bad value
-          # ... But only in the test binary, presumably because it somehow ends
-          # up using the symbol in a problematic way.
-          "-Crelocation-model=pic"
-        ];
+        # CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS = [
+        #   "-L${pkgs.pkgsCross.musl64.pkgsStatic.stdenv.cc.cc.lib}/x86_64-unknown-linux-musl/lib"
+        #   "-lstatic=stdc++"
+        #   "-Ctarget-feature=+crt-static"
+        #   # The default of static pie executables results in the error message:
+        #   # > x86_64-unknown-linux-musl-ld: gcc-12.2.0-lib/x86_64-unknown-linux-musl/lib/libstdc++.a(compatibility.o):
+        #   # >   relocation R_X86_64_32 against symbol `__gxx_personality_v0' can not be used when making a PIE object; recompile with -fPIE
+        #   # > x86_64-unknown-linux-musl-ld: failed to set dynamic section sizes: bad value
+        #   # ... But only in the test binary, presumably because it somehow ends
+        #   # up using the symbol in a problematic way.
+        #   "-Crelocation-model=pic"
+        # ];
         CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = "x86_64-unknown-linux-musl-ld";
         CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER = "cc";
 
@@ -82,7 +82,7 @@
         # relating to our handling of file permissions which needs
         # fixing, but this may work.)
         CC_x86_64_pc_windows_gnu = "x86_64-w64-mingw32-gcc";
-        CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS = "-L${pkgs.pkgsCross.mingwW64.stdenv.cc.cc.lib}/x86_64-w64-mingw32/lib -lstatic=stdc++.dll";
+        # CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS = "-L${pkgs.pkgsCross.mingwW64.stdenv.cc.cc.lib}/x86_64-w64-mingw32/lib -lstatic=stdc++.dll";
         CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER = "x86_64-w64-mingw32-ld";
         CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER = pkgs.writeScript "wine-wrapper" ''
           export WINEPREFIX="$(mktemp -d)"

--- a/src/bin/elfshaker/main.rs
+++ b/src/bin/elfshaker/main.rs
@@ -14,7 +14,7 @@ mod store;
 mod update;
 mod utils;
 
-use clap::{App, Arg, ArgMatches};
+use clap::{crate_version, App, Arg, ArgMatches};
 use elfshaker::log::Logger;
 use log::error;
 use std::error::Error;
@@ -65,6 +65,7 @@ fn run_subcommand(app: &mut App, matches: ArgMatches) -> Result<(), Box<dyn Erro
 
 fn get_app() -> App<'static, 'static> {
     App::new("elfshaker")
+        .version(crate_version!())
         .subcommand(extract::get_app())
         .subcommand(store::get_app())
         .subcommand(list::get_app())

--- a/test-scripts/check.sh
+++ b/test-scripts/check.sh
@@ -23,7 +23,7 @@ input=$(realpath "$2")
 pack=$(basename -- "$input")
 pack="${pack%.*}"
 
-temp_dir=$(realpath /dev/shm/"test-T$(timestamp)")
+temp_dir=$(realpath ${TMP-${TMPDIR-/tmp}}/"test-T$(timestamp)")
 trap 'trap_exit' EXIT
 
 cleanup() {


### PR DESCRIPTION
* Bump the version number to 1.0.0-rc1 (note, the RC won't be official until it's tagged and there are binaries on the release page).
* Fix elfshaker --version showing the version number
* Update the nix build infrastructure so that cross compiling works better. Not all cross configurations work, so we'll need a Linux builder and two Darwin builders (aarch64/x86) if we want a full(ish) complement of binaries. See notes in the commit message.

The key is that you can type `nix build .#release` and you'll get the cross-built release artefacts that your machine is capable of building.

They should be reproducible since everything is locked to a specific revision. I've also got all of the build dependencies in a cachix.org cache that the build infrastructure can use so it should be fairly fast to materialize binaries.

I plan to test this a little more and then push it when I'm ready. Review comments and questions are welcome if anyone reading this spots anything or wants to learn more.