### PR TITLE
Make elfshaker build on Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //! Copyright (C) 2021 Arm Limited or its affiliates and Contributors. All rights reserved.
 
+#[cfg(unix)]
 pub mod atomicfile;
 pub mod batch;
 pub mod entrypool;

--- a/src/packidx.rs
+++ b/src/packidx.rs
@@ -577,7 +577,7 @@ fn os_str_as_bytes(os_str: &OsStr) -> Cow<[u8]> {
 
 #[cfg(not(unix))]
 fn os_str_as_bytes(os_str: &OsStr) -> Cow<[u8]> {
-    Cow::Owned(os_str.to_string_lossy().as_bytes())
+    Cow::Owned(os_str.to_string_lossy().as_bytes().into())
 }
 
 impl PackIndex {

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -1342,12 +1342,12 @@ mod tests {
         fs::remove_file(&test_lock).unwrap();
         let path = repo.loose_object_path(&checksum);
         assert_eq!(
-            format!(
-                "{}/{}/fa/f0/deadbeefbadc0de0faf0deadbeefbadc0de0",
-                repo.data_dir().to_string_lossy(),
-                LOOSE_DIR
-            ),
-            path.to_str().unwrap(),
+            repo.data_dir()
+                .join(LOOSE_DIR)
+                .join("fa")
+                .join("f0")
+                .join("deadbeefbadc0de0faf0deadbeefbadc0de0"),
+            path,
         );
     }
 

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -1,14 +1,13 @@
 //! SPDX-License-Identifier: Apache-2.0
 //! Copyright (C) 2021 Arm Limited or its affiliates and Contributors. All rights reserved.
 
-use super::{constants::*, pack::IdError};
+use super::{constants::*, fs::set_file_mode, pack::IdError};
 
 use std::{
     collections::{HashMap, HashSet},
-    fs::{self, File, Permissions},
+    fs::{self, File},
     io,
     io::{Read, Write},
-    os::unix::prelude::PermissionsExt,
     path::{Path, PathBuf},
     str::FromStr,
     sync::atomic::{AtomicBool, Ordering},
@@ -27,7 +26,7 @@ use super::constants::REPO_DIR;
 use super::error::Error;
 use super::fs::{
     create_file, create_temp_path, ensure_dir, get_last_modified, open_file, write_file_atomic,
-    EmptyDirectoryCleanupQueue,
+    EmptyDirectoryCleanupQueue, FileMode, MetadataFileModeExt,
 };
 use super::pack::{write_skippable_frame, Pack, PackFrame, PackHeader, PackId, SnapshotId};
 use super::remote;
@@ -587,7 +586,7 @@ impl Repository {
             let (buf, mode) = {
                 let mut buf = vec![];
                 fd.read_to_end(&mut buf)?;
-                let mode = fd.metadata()?.permissions().mode();
+                let mode = fd.metadata()?.file_mode();
                 (buf, mode)
             };
             let mut checksum = [0u8; 20];
@@ -603,7 +602,7 @@ impl Repository {
                     offset: LOOSE_OBJECT_OFFSET,
                     size: buf.len() as u64,
                 },
-                FileMetadata { mode },
+                FileMetadata { mode: mode.0 },
             ))
         })
         .into_iter()
@@ -1029,8 +1028,8 @@ impl Repository {
                 )
             })?;
 
-            let perm = Permissions::from_mode(entry.file_metadata.mode);
-            fs::set_permissions(&dest_path, perm)?
+            let file_mode = FileMode(entry.file_metadata.mode);
+            set_file_mode(&dest_path, file_mode)?
         }
 
         if verify {


### PR DESCRIPTION
This makes the build pass on Windows, however, there is likely more work to make sure we actually work correctly. 

The tests script that we have cannot be run on Windows easily, so we cannot verify that we actually function. My feeling is the best approach is likely to rewrite the functional tests we have in Rust and run them via cargo in the same way. It appears one of the ways to deal with expensive tests is to mark them as ignored, then run them when desired with `cargo test -- --ignored`. https://github.com/rust-lang/rust/blob/054b7b7/src/libcoretest/num/flt2dec/strategy/grisu.rs#L56