### PR TITLE
Atomicfile fixes

### DIFF
--- a/.github/workflows/test-nix.yml
+++ b/.github/workflows/test-nix.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: docker/setup-qemu-action@v2
       - name: Build
-        run: nix build .#release
+        run: nix build --log-lines 1000 .#release
       - name: ls
         run: ls -la result/
 
@@ -26,6 +26,6 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Build
-        run: nix build .#release
+        run: nix build --log-lines 1000 .#release
       - name: ls
         run: ls -la result/


### PR DESCRIPTION
An attempt to fix the atomicfile issue which cropped up in #66; if this doesn't fix it, I suggest we remove the atomicfile api. I would still like to make use of this, but at the end of the day it would still exist in the git history to be resurrected if it were deleted.