### PR TITLE
Replace magic-nix-cache-action

### DIFF
--- a/.github/workflows/test-nix.yml
+++ b/.github/workflows/test-nix.yml
@@ -11,8 +11,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: nixbuild/nix-quick-install-action@master
+      - uses: nix-community/cache-nix-action@main
+        with:
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
       - uses: docker/setup-qemu-action@v2
       - name: Build
         run: nix build --log-lines 1000 .#release
@@ -23,8 +26,11 @@ jobs:
     runs-on: macos-13 # 13 runner is x86.
     steps:
       - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: nixbuild/nix-quick-install-action@master
+      - uses: nix-community/cache-nix-action@main
+        with:
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
       - name: Build
         run: nix build --log-lines 1000 .#release
       - name: ls
@@ -34,8 +40,11 @@ jobs:
     runs-on: macos-14 # 14 runner is aarch64.
     steps:
       - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: nixbuild/nix-quick-install-action@master
+      - uses: nix-community/cache-nix-action@main
+        with:
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
       - name: Build
         run: nix build --log-lines 1000 .#release
       - name: ls


### PR DESCRIPTION
The `DeterminateSystems/magic-nix-cache-action` action has been [deprecated](https://determinate.systems/posts/magic-nix-cache-free-tier-eol/) and no longer works. This PR replaces it with the `nix-community/cache-nix-action` action, which is actively maintained. It also replaces the `DeterminateSystems/nix-installer-action` action with the `nixbuild/nix-quick-install-action` action, which is required for the cache action to work. The cache has been configured to restore based on the runner's OS and architecture, so it should work on any runner.
