### PR TITLE
Fix locking on NFS

### DIFF
--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -182,7 +182,10 @@ impl Repository {
             return Err(Error::RepositoryNotFound);
         }
 
-        let lock_file = match fs::File::create(data_dir.join("mutex")) {
+        let mut open_options = fs::OpenOptions::new();
+        let open_options = open_options.create(true).write(true).read(true);
+
+        let lock_file = match open_options.open(data_dir.join("mutex")) {
             Ok(lock_file) => {
                 if let Err(e) = fs2::FileExt::try_lock_shared(&lock_file) {
                     if e.raw_os_error() == fs2::lock_contended_error().raw_os_error() {


### PR DESCRIPTION
On NFS I get `EBADF` from `flock` unless the file is opened for reading in addition to writing, so open it with reading and writing enabled.