### PR TITLE
Improve missing repo error

### DIFF
--- a/src/repo/error.rs
+++ b/src/repo/error.rs
@@ -2,6 +2,7 @@
 //! Copyright (C) 2021 Arm Limited or its affiliates and Contributors. All rights reserved.
 
 use std::ffi::OsString;
+use std::path::PathBuf;
 use std::{fmt::Display, io};
 
 use crate::packidx::PackError;
@@ -33,7 +34,7 @@ pub enum Error {
     /// The .pack file is not available in packs/
     PackNotFound(String),
     /// The directory is not a repository
-    RepositoryNotFound,
+    RepositoryNotFound(PathBuf),
     // The loose object is corrupt or is in the wrong path
     BadLooseObject(String),
     /// The .esi file is corrupted.
@@ -81,7 +82,23 @@ impl Display for Error {
                 f,
                 "The specified pack file '{p}' could not be found in the repository index!",
             ),
-            Self::RepositoryNotFound => write!(f, "The directory is not an elfshaker repository!"),
+            Self::RepositoryNotFound(p) => write!(
+                f,
+                "Missing data directory.\
+                 \n\nThe path {:?} is missing, so not in an elfshaker repository!\n\
+                 \n\
+                 To create a new repository:
+                   elfshaker store <snapshot name>\n\
+                 (This will create a new repo with a snapshot.)\n\
+                 \n\
+                 To clone an existing repository:
+                   elfshaker clone <url to esi> <directory>\n\
+                 \n\
+                 Alternatively, you can set the environment variable ELFSHAKER_DATA\n\
+                 to point to a repository, or supply --data-dir to specify the\n\
+                 repository location.",
+                p
+            ),
             Self::BadLooseObject(s) => write!(f, "Bad loose object: {s}"),
             Self::HttpError(e) => e.fmt(f),
             Self::BadRemoteIndexFormat(e) => e.fmt(f),

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -6,12 +6,13 @@ use super::{constants::*, fs::set_file_mode, pack::IdError};
 use std::{
     collections::{HashMap, HashSet},
     fs::{self, File},
-    io,
-    io::{Read, Write},
+    io::{self, Read, Write},
     path::{Path, PathBuf},
     str::FromStr,
-    sync::atomic::{AtomicBool, Ordering},
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
     time::SystemTime,
 };
 
@@ -172,15 +173,12 @@ impl Repository {
         P2: AsRef<Path>,
     {
         let path = path.as_ref().to_path_buf();
-        let data_dir = data_dir.as_ref().canonicalize()?;
+        let data_dir = data_dir.as_ref();
 
-        if !Path::exists(&data_dir) {
-            error!(
-                "The directory {:?} is not an elfshaker repository!",
-                data_dir.parent().unwrap_or_else(|| Path::new("/"))
-            );
-            return Err(Error::RepositoryNotFound);
+        if !Path::exists(data_dir) {
+            return Err(Error::RepositoryNotFound(data_dir.to_path_buf()));
         }
+        let data_dir = data_dir.canonicalize()?;
 
         let lock_file = match fs::File::create(data_dir.join("mutex")) {
             Ok(lock_file) => {


### PR DESCRIPTION
Previously:

```
[ERROR (main) 29.042µs]: *FATAL*: No such file or directory (os error 2) (NotFound)
```

Now:

```
[ERROR (main) 8.875µs]: *FATAL*: Missing data directory.

The path "elfshaker_data" is missing, so not in an elfshaker repository!

To create a new repository:
                   elfshaker store <snapshot name>
(This will create a new repo with a snapshot.)

To clone an existing repository:
                   elfshaker clone <url to esi> <directory>

Alternatively, you can set the environment variable ELFSHAKER_DATA
to point to a repository, or supply --data-dir to specify the
repository location.
```

It's a bit verbose but I hope more helpful to newcomers.

Previously we were failing during canonicalise, which has an internal existence check, before we reached our human-error type.