### PR TITLE
Fix path changing between regular file and directory

### DIFF
--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -131,8 +131,7 @@ pub fn create_with_mode<P: AsRef<Path>>(path: P, mode: u32) -> io::Result<File> 
 pub fn create_empty<P: AsRef<Path>>(path: P, mode: u32) -> io::Result<()> {
     let tmp = create_temp_path(path.as_ref().parent().unwrap());
     create_with_mode(&tmp, mode)?;
-    fs::rename(tmp, path)?;
-    Ok(())
+    fs::rename(tmp, path)
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -497,7 +497,12 @@ impl Repository {
             path_buf.push(path);
             // Delete the file
             match fs::remove_file(&path_buf) {
+                // Nothing to remove.
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                // It's a directory, delete recursively.
+                Err(e) if e.kind() == std::io::ErrorKind::IsADirectory => {
+                    fs::remove_dir_all(&path_buf)
+                }
                 r => r,
             }?;
 


### PR DESCRIPTION
If a directory is being overwritten with a regular file, it's necessary to unlink everything in the directory first.

This was revealed by #141.