### PR TITLE
Add third-party directory to `git restore` and fix commit set

### DIFF
--- a/contrib/manyclangs-build-month
+++ b/contrib/manyclangs-build-month
@@ -28,9 +28,11 @@ commits_for_month() {
 
     # Consider only commits touching these directories of interest.
     INTERESTING_PATHS=(
-        llvm
         clang
+        clang-tools-extra
         cmake
+        llvm
+        third-party
     )
     git-list-between origin/main "${FROM_INCL}" "${TO_EXCL}" -- "${INTERESTING_PATHS[@]}"
 }
@@ -112,7 +114,7 @@ _manyclangs_build_part() {
         # efficient.
         (cd .. &&
          git restore --no-progress --staged --worktree --source="$COMMIT_SHA" -- \
-             {llvm,clang,clang-tools-extra} :^{llvm,clang,clang-tools-extra}/test "${EXTRA[@]}"
+             {llvm,clang,clang-tools-extra,third-party} :^{llvm,clang,clang-tools-extra}/test "${EXTRA[@]}"
         )
 
         echo "$COMMIT_SHA" > COMMIT_SHA


### PR DESCRIPTION
LLVM commit 7f3afab9181d83f92771293ad3b6c00ac62800fd added a dependency from llvm to the third-party directory. Make sure we check out and capture changes to this directory.

While we're here, add clang-tools-extra to the set of commits being considered for build. Note its absence means a small inaccuracy if you are trying to bisect a bug in a clang-tools-extra project which was caused by a commit which only modifies that directory.