### PR TITLE
manyclangs: Include clangd

### DIFF
--- a/contrib/manyclangs-cmake
+++ b/contrib/manyclangs-cmake
@@ -51,7 +51,7 @@ FLAGS=(
     "-DCMAKE_BUILD_TYPE=Release"
     "-DLLVM_ENABLE_ASSERTIONS=On"
     "-DLLVM_ENABLE_PROJECTS=clang;clang-tools-extra"
-    "-DCLANG_ENABLE_CLANGD=Off"
+    "-DCLANGD_DECISION_FOREST=Off"
 
     # VC revision is written into binaries with manyclangs-build. This is not
     # used because it invalidates tablegen which causes a lot of rebuilding.


### PR DESCRIPTION
Enable clangd when building packs.

The decision forest code completion model is disabled because buildng it involves a code generation step and I couldn't readily figure out how to get the build to work with that.