### PR TITLE
contrib/manyclangs-setup.sh: install gawk

### DIFF
--- a/contrib/manyclangs-setup.sh
+++ b/contrib/manyclangs-setup.sh
@@ -58,6 +58,7 @@ install_system_dependencies() {
         command -v cc &&
         command -v clang-${MANYCLANGS_CLANG_VERSION} &&
         command -v curl &&
+        command -v gawk &&
         command -v git &&
         command -v go &&
         command -v jq &&
@@ -74,6 +75,7 @@ install_system_dependencies() {
     PKGS=(
         clang-${MANYCLANGS_CLANG_VERSION}
         curl
+        gawk
         g++
         gcc
         git


### PR DESCRIPTION
On a default Ubuntu 20.04 install, `awk` points to `mawk`.

However, the manyclangs scripts use `awk -c` which is only supported by `gawk`.