### PR TITLE
Replace unmaintained rust-crypto with sha1 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +189,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +211,26 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -219,10 +257,10 @@ dependencies = [
  "libc",
  "log",
  "num_cpus",
- "rand 0.9.1",
+ "rand",
  "rmp-serde",
- "rust-crypto",
  "serde",
+ "sha1",
  "ureq",
  "url",
  "walkdir",
@@ -272,16 +310,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
+name = "generic-array"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -612,35 +648,12 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
-dependencies = [
- "libc",
- "rand 0.4.6",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -650,23 +663,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -675,15 +673,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -721,25 +710,6 @@ dependencies = [
  "rmp",
  "serde",
 ]
-
-[[package]]
-name = "rust-crypto"
-version = "0.2.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
-dependencies = [
- "gcc",
- "libc",
- "rand 0.3.23",
- "rustc-serialize",
- "time",
-]
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "rustls"
@@ -812,6 +782,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,17 +845,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,6 +853,12 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -936,6 +912,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,12 +926,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -1064,7 +1040,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ zstd = { version = "0.13.3", features = ["zstdmt"] }
 crossbeam-utils = "0.8"
 walkdir = "2.5.0"
 clap = { version = "4", features = ["color", "env", "error-context", "help", "usage"] }
-rust-crypto = "0.2.36"
+sha1 = "0.10"
 hashbrown = "0.15.3"
 hex = "0.4.3"
 chrono = "0.4.41"

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -5,8 +5,7 @@
 use crate::packidx::ObjectChecksum;
 use crate::progress::ProgressReporter;
 use crate::repo::run_in_parallel;
-use crypto::digest::Digest;
-use crypto::sha1::Sha1;
+use sha1::{Digest, Sha1};
 use std::{
     fs,
     io::{self, Read, Write},
@@ -22,11 +21,9 @@ where
 {
     run_in_parallel(num_cpus::get(), paths.iter(), |path| {
         let buf = fs::read(path)?;
-        let checksum_buf = &mut [0u8; 20];
         let mut hasher = Sha1::new();
-        hasher.input(&buf);
-        hasher.result(checksum_buf);
-        Ok(*checksum_buf)
+        hasher.update(&buf);
+        Ok(hasher.finalize().into())
     })
     .into_iter()
     .collect::<io::Result<Vec<_>>>()

--- a/src/packidx.rs
+++ b/src/packidx.rs
@@ -9,9 +9,9 @@ use crate::repo::{
     partition_by_u64,
 };
 
-use sha1::{Digest, Sha1};
 use serde::de::{SeqAccess, Visitor};
 use serde::{ser::SerializeTuple, Deserialize, Deserializer, Serialize, Serializer};
+use sha1::{Digest, Sha1};
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashSet};
 use std::ffi::{OsStr, OsString};

--- a/src/packidx.rs
+++ b/src/packidx.rs
@@ -9,8 +9,7 @@ use crate::repo::{
     partition_by_u64,
 };
 
-use crypto::digest::Digest;
-use crypto::sha1::Sha1;
+use sha1::{Digest, Sha1};
 use serde::de::{SeqAccess, Visitor};
 use serde::{ser::SerializeTuple, Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::Cow;
@@ -558,15 +557,13 @@ impl PackIndex {
         // Map FileHandle to FileEntry, which contains path and checksum
         let mut entries = self.entry_refs_from_handles(handles.iter()).ok()?;
         entries.sort_by(|a, b| a.checksum.cmp(b.checksum).then(a.path.cmp(b.path)));
-        let mut hasher = entries.into_iter().fold(Sha1::new(), |mut hasher, entry| {
-            hasher.input(&os_str_as_bytes(entry.path));
-            hasher.input(entry.checksum);
-            hasher.input(&entry.file_metadata.mode.to_be_bytes());
+        let hasher = entries.into_iter().fold(Sha1::new(), |mut hasher, entry| {
+            hasher.update(os_str_as_bytes(entry.path));
+            hasher.update(entry.checksum);
+            hasher.update(entry.file_metadata.mode.to_be_bytes());
             hasher
         });
-        let mut checksum: ObjectChecksum = [0; 20];
-        hasher.result(&mut checksum);
-        Some(checksum)
+        Some(hasher.finalize().into())
     }
 }
 

--- a/src/repo/pack.rs
+++ b/src/repo/pack.rs
@@ -12,8 +12,7 @@ use std::{
 };
 use std::{fmt::Display, str::FromStr};
 
-use crypto::digest::Digest;
-use crypto::sha1::Sha1;
+use sha1::{Digest, Sha1};
 
 use log::info;
 
@@ -483,10 +482,9 @@ impl Pack {
 /// Verifies that the object has the expected checksum.
 fn verify_object(buf: &[u8], exp_checksum: &ObjectChecksum) -> Result<(), Error> {
     // Verify checksum
-    let mut checksum = [0u8; 20];
     let mut hasher = Sha1::new();
-    hasher.input(buf);
-    hasher.result(&mut checksum);
+    hasher.update(buf);
+    let checksum: [u8; 20] = hasher.finalize().into();
     if &checksum != exp_checksum {
         return Err(PackError::ChecksumMismatch(*exp_checksum, checksum).into());
     }

--- a/src/repo/remote.rs
+++ b/src/repo/remote.rs
@@ -8,8 +8,7 @@ use std::{
 };
 
 use chrono::{offset::Utc, DateTime};
-use crypto::digest::Digest;
-use crypto::sha1::Sha1;
+use sha1::{Digest, Sha1};
 use ureq::Agent;
 use url::Url;
 
@@ -392,10 +391,9 @@ pub fn update_remote_pack(
         let mut writer = ProgressWriter::with_known_size(&mut data, reporter, content_length);
         io::copy(&mut reader, &mut writer)?;
 
-        let mut checksum = [0u8; 20];
         let mut hasher = Sha1::new();
-        hasher.input(&data);
-        hasher.result(&mut checksum);
+        hasher.update(&data);
+        let checksum: [u8; 20] = hasher.finalize().into();
 
         if checksum == remote_pack.pack_checksum {
             create_file(pack_path, None)?.write_all(&data)?;
@@ -540,14 +538,11 @@ fn compute_checksum(path: &Path) -> io::Result<ObjectChecksum> {
         if len == 0 {
             break;
         }
-        sha1.input(buf);
+        sha1.update(buf);
         reader.consume(len);
     }
 
-    let mut checksum = [0u8; 20];
-    sha1.result(&mut checksum);
-
-    Ok(checksum)
+    Ok(sha1.finalize().into())
 }
 
 /// Formats a [`SystemTime`] as an HTTP date string. HTTP dates are always in

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -16,8 +16,6 @@ use std::{
     time::SystemTime,
 };
 
-use crypto::digest::Digest;
-use crypto::sha1::Sha1;
 use fs2::FileExt;
 use log::{error, info, warn};
 use walkdir::WalkDir;
@@ -40,6 +38,7 @@ use crate::{
     packidx::{FileEntry, FileMetadata, ObjectChecksum, PackError, PackIndex},
     repo::fs::create_empty,
 };
+use sha1::{Digest, Sha1};
 
 /// A struct specifying the the extract options.
 #[derive(Clone, Debug)]
@@ -634,10 +633,9 @@ impl Repository {
                 let mode = fd.metadata()?.file_mode();
                 (buf, mode)
             };
-            let mut checksum = [0u8; 20];
             let mut hasher = Sha1::new();
-            hasher.input(&buf);
-            hasher.result(&mut checksum);
+            hasher.update(&buf);
+            let checksum: [u8; 20] = hasher.finalize().into();
             self.write_loose_object(&*buf, &temp_dir, &checksum)?;
 
             Ok(FileEntry::new(


### PR DESCRIPTION
rust-crypto has been unmaintained since 2016 and is flagged by RUSTSEC-2022-0011. Its only transitive dependency of note, rustc-serialize, is likewise deprecated. elfshaker only uses rust-crypto for SHA-1 hashing, in five spots: batch checksumming, snapshot creation, pack verification, remote pack verification, and snapshot checksum computation.

Swap it for the maintained RustCrypto `sha1` crate. Hash output is byte-identical, so existing packs remain valid.

An LLM was used to create this change. I reviewed the changes, but I have little to no prior Rust experience.