### PR TITLE
manyclangs: restore LLVM libc and support repairs

### DIFF
--- a/contrib/manyclangs-build-month
+++ b/contrib/manyclangs-build-month
@@ -10,6 +10,11 @@ print_help() {
     echo ''
     echo 'manyclangs-build-month is a "set it and forget it" script that builds'
     echo 'the specified month and produces a .pack file.'
+    echo ''
+    echo 'Repair controls:'
+    echo '  MANYCLANGS_COMMIT_LIST_FILE  use an exact SHA/snapshot input list'
+    echo '  MANYCLANGS_REBUILD_EXISTING  rebuild snapshots with existing loose indexes'
+    echo '  MANYCLANGS_PACK_NAME         choose the output pack name'
 }
 
 commits_for_month() {
@@ -31,10 +36,66 @@ commits_for_month() {
         clang
         clang-tools-extra
         cmake
+        libc
         llvm
         third-party
     )
     git-list-between origin/main "${FROM_INCL}" "${TO_EXCL}" -- "${INTERESTING_PATHS[@]}"
+}
+
+validate_commit_list() {
+    local COMMIT_LIST=$1
+    local YEAR=$2
+    local MONTH=$3
+    local LINE_NUMBER=0
+    local COMMIT_SHA
+    local SNAPSHOT_NAME
+    local EXTRA
+    declare -A SEEN_SNAPSHOTS=()
+
+    while IFS= read -r LINE || [[ -n "$LINE" ]]
+    do
+        ((LINE_NUMBER+=1))
+        read -r COMMIT_SHA SNAPSHOT_NAME EXTRA <<< "$LINE"
+        if [[ -z "${COMMIT_SHA-}" || -z "${SNAPSHOT_NAME-}" || -n "${EXTRA-}" ]]
+        then
+            echo "manyclangs-build-month: ${COMMIT_LIST}:${LINE_NUMBER}: expected COMMIT_SHA SNAPSHOT_NAME" >&2
+            return 1
+        fi
+        if [[ ! "$COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+           ! git cat-file -e "${COMMIT_SHA}^{commit}" 2>/dev/null
+        then
+            echo "manyclangs-build-month: ${COMMIT_LIST}:${LINE_NUMBER}: invalid commit $COMMIT_SHA" >&2
+            return 1
+        fi
+        if [[ ! "$SNAPSHOT_NAME" =~ ^${YEAR}${MONTH}[0-9]{2}- ]]
+        then
+            echo "manyclangs-build-month: ${COMMIT_LIST}:${LINE_NUMBER}: snapshot $SNAPSHOT_NAME is outside $YEAR$MONTH" >&2
+            return 1
+        fi
+        if [[ -n "${SEEN_SNAPSHOTS[$SNAPSHOT_NAME]-}" ]]
+        then
+            echo "manyclangs-build-month: ${COMMIT_LIST}:${LINE_NUMBER}: duplicate snapshot $SNAPSHOT_NAME" >&2
+            return 1
+        fi
+        SEEN_SNAPSHOTS[$SNAPSHOT_NAME]=1
+    done < "$COMMIT_LIST"
+
+    if [[ "$LINE_NUMBER" -eq 0 ]]
+    then
+        echo "manyclangs-build-month: commit list is empty: $COMMIT_LIST" >&2
+        return 1
+    fi
+}
+
+validate_pack_name() {
+    local PACK_NAME=$1
+    if [[ ! "$PACK_NAME" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] ||
+       [[ "$PACK_NAME" == loose ]]
+    then
+        echo "manyclangs-build-month: unsafe pack name: $PACK_NAME" >&2
+        return 1
+    fi
 }
 
 _manyclangs_list_files0_to_pack() {
@@ -93,28 +154,35 @@ _manyclangs_build_part() {
 
     while read -r COMMIT_SHA SNAPSHOT_NAME
     do
-        if [ -e "elfshaker_data/packs/loose/${SNAPSHOT_NAME}.pack.idx" ]
+        if [[ -z "${MANYCLANGS_REBUILD_EXISTING-}" ]] &&
+           [ -e "elfshaker_data/packs/loose/${SNAPSHOT_NAME}.pack.idx" ]
         then
             echo "manyclangs-build-month: Skip already built commit $SNAPSHOT_NAME"
             echo "Skipped $SNAPSHOT_NAME @ $(date "+%Y/%m/%d %H:%M:%S")" 1>&30 # for progress output.
             continue
         fi
         echo "manyclangs-build-month: Building commit $SNAPSHOT_NAME"
+        rm -f "${HASHES_DIR}/${SNAPSHOT_NAME}.txt"
 
-        EXTRA=()
+        RESTORE_PATHS=(llvm clang clang-tools-extra third-party)
         # Detect the cmake top-level directory introduced Jan 2022.
         if git ls-tree "$COMMIT_SHA":cmake &> /dev/null;
         then
-            EXTRA+=(cmake)
+            RESTORE_PATHS+=(cmake)
+        fi
+        if git ls-tree "$COMMIT_SHA":libc &> /dev/null;
+        then
+            RESTORE_PATHS+=(libc)
         fi
 
-        # Handy comand which sets the sources in ./llvm ./clang to the right
+        # Handy command which sets the source directories to the right
         # contents efficiently (including removing files which have gone). It
         # makes use of the $GIT_INDEX_FILE to keep track of the old state so is
         # efficient.
         (cd .. &&
          git restore --no-progress --staged --worktree --source="$COMMIT_SHA" -- \
-             {llvm,clang,clang-tools-extra,third-party} :^{llvm,clang,clang-tools-extra}/test "${EXTRA[@]}"
+             "${RESTORE_PATHS[@]}" \
+             :^llvm/test :^clang/test :^clang-tools-extra/test
         )
 
         echo "$COMMIT_SHA" > COMMIT_SHA
@@ -207,13 +275,24 @@ main() {
 
     YEAR="$1"
     MONTH="$2"
-    MANYCLANGS_PACK_NAME="$(uname -m)-${MANYCLANGS_PACK_TYPE-ubuntu2004}-manyclangs-$YEAR$MONTH"
+    ELFSHAKER_DATA=${ELFSHAKER_DATA-$PWD/elfshaker_data}
+    export ELFSHAKER_DATA
+    MANYCLANGS_PACK_NAME=${MANYCLANGS_PACK_NAME:-"$(uname -m)-${MANYCLANGS_PACK_TYPE-ubuntu2004}-manyclangs-$YEAR$MONTH"}
 
     date -d "$YEAR/$MONTH/01" 1>/dev/null || { print_help; exit 1; }
+    validate_pack_name "$MANYCLANGS_PACK_NAME"
 
-    commits_for_month "$YEAR" "$MONTH"  > manyclangs-commit-list.txt
-    apply_limit < manyclangs-commit-list.txt | apply_subset > manyclangs-commit-list.txt.subset
-    mv manyclangs-commit-list.txt.subset manyclangs-commit-list.txt
+    if [[ -n "${MANYCLANGS_COMMIT_LIST_FILE-}" ]]
+    then
+        cat "$MANYCLANGS_COMMIT_LIST_FILE" > manyclangs-commit-list.txt.input
+        validate_commit_list manyclangs-commit-list.txt.input "$YEAR" "$MONTH"
+        mv manyclangs-commit-list.txt.input manyclangs-commit-list.txt
+    else
+        commits_for_month "$YEAR" "$MONTH" > manyclangs-commit-list.txt
+        apply_limit < manyclangs-commit-list.txt | apply_subset > manyclangs-commit-list.txt.subset
+        mv manyclangs-commit-list.txt.subset manyclangs-commit-list.txt
+        validate_commit_list manyclangs-commit-list.txt "$YEAR" "$MONTH"
+    fi
     COMMIT_COUNT=$(wc -l manyclangs-commit-list.txt | awk '{print $1}')
 
     NPARALLEL=${MANYCLANGS_NPARALLEL-5} # Number of parts to run in parallel.
@@ -286,29 +365,37 @@ Sleeping 5 seconds, CTRL-C to abort, or wait to continue.
             | { if [ "${INTERACTIVE}" ]; then progress_bar "$COMMIT_COUNT"; else cat; fi; }
     fi
 
-    # Globs are already sorted.
-    SNAPSHOTS_SORTED=(elfshaker_data/packs/loose/${YEAR}${MONTH}*)
-    SNAPSHOTS_SORTED=("${SNAPSHOTS_SORTED[@]%.pack.idx}")
-    SNAPSHOTS_SORTED=("${SNAPSHOTS_SORTED[@]#elfshaker_data/packs/}")
+    mapfile -t SNAPSHOTS_SORTED < <(
+        find "$ELFSHAKER_DATA/packs/loose" \
+            -maxdepth 1 \
+            -type f \
+            -name "${YEAR}${MONTH}*.pack.idx" \
+            -printf 'loose/%f\n' |
+            sed 's/\.pack\.idx$//' |
+            sort
+    )
 
     time elfshaker pack "$MANYCLANGS_PACK_NAME" "${SNAPSHOTS_SORTED[@]}"
     echo
     echo
     echo "manyclangs-build-month $YEAR $MONTH all done, here are the resulting files:"
     echo
-    du -sch elfshaker_data/packs/"${MANYCLANGS_PACK_NAME}".pack{,.idx}
+    du -sch "$ELFSHAKER_DATA"/packs/"${MANYCLANGS_PACK_NAME}".pack{,.idx}
     echo
     echo "(A typical 1 month upstream pack takes 100MiB storage)"
     echo
 }
 
-case "${1:--h}" in
-    -h | --help)
-        print_help
-        [ $# -ne 0 ]
-        exit $?
-        ;;
-    *)
-        main "$@"
-        ;;
-esac
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]
+then
+    case "${1:--h}" in
+        -h | --help)
+            print_help
+            [ $# -ne 0 ]
+            exit $?
+            ;;
+        *)
+            main "$@"
+            ;;
+    esac
+fi

--- a/contrib/test-manyclangs-build-month
+++ b/contrib/test-manyclangs-build-month
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+SCRIPT="$SCRIPT_DIR/manyclangs-build-month"
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/test-manyclangs-build-month.XXXXXX")
+trap 'rm -r "$TEST_ROOT"' EXIT
+
+fail() {
+    echo "test-manyclangs-build-month: $*" >&2
+    exit 1
+}
+
+REPOSITORY="$TEST_ROOT/llvm-project"
+mkdir -p "$REPOSITORY"
+git -C "$REPOSITORY" init -q
+git -C "$REPOSITORY" config user.email test@example.com
+git -C "$REPOSITORY" config user.name Test
+for DIRECTORY in llvm clang clang-tools-extra cmake libc third-party
+do
+    mkdir -p "$REPOSITORY/$DIRECTORY"
+    echo "$DIRECTORY" > "$REPOSITORY/$DIRECTORY/sentinel"
+done
+git -C "$REPOSITORY" add .
+git -C "$REPOSITORY" commit -qm "fixture"
+COMMIT_SHA=$(git -C "$REPOSITORY" rev-parse HEAD)
+SNAPSHOT_NAME=20260501-00001T000000-"${COMMIT_SHA:0:15}"
+
+BIN="$TEST_ROOT/bin"
+mkdir -p "$BIN"
+for COMMAND in jobserver jq compdb2line ninja ninja-jobclient cmake clang-12 clang++-12
+do
+    ln -s "$(type -P true)" "$BIN/$COMMAND"
+done
+
+cat > "$BIN/manyclangs-build" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+test -f ../libc/sentinel
+printf 'object\n' > fixture.o
+printf 'ninja\n' > build.ninja
+EOF
+chmod +x "$BIN/manyclangs-build"
+
+cat > "$BIN/elfshaker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+COMMAND=$1
+shift
+case "$COMMAND" in
+    store)
+        SNAPSHOT_NAME=${!#}
+        mkdir -p "$ELFSHAKER_DATA/packs/loose"
+        cat >/dev/null
+        printf 'stored\n' > "$ELFSHAKER_DATA/packs/loose/$SNAPSHOT_NAME.pack.idx"
+        printf 'store %s\n' "$SNAPSHOT_NAME" >> "$ELFSHAKER_TEST_EVENTS"
+        ;;
+    pack)
+        PACK_NAME=$1
+        mkdir -p "$ELFSHAKER_DATA/packs"
+        printf 'pack\n' > "$ELFSHAKER_DATA/packs/$PACK_NAME.pack"
+        printf 'index\n' > "$ELFSHAKER_DATA/packs/$PACK_NAME.pack.idx"
+        printf 'pack %s\n' "$PACK_NAME" >> "$ELFSHAKER_TEST_EVENTS"
+        ;;
+    *)
+        echo "unexpected elfshaker command: $COMMAND" >&2
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$BIN/elfshaker"
+
+COMMIT_LIST="$TEST_ROOT/repair-commits.txt"
+printf '%s %s\n' "$COMMIT_SHA" "$SNAPSHOT_NAME" > "$COMMIT_LIST"
+
+ELFSHAKER_DATA="$TEST_ROOT/elfshaker_data"
+EVENTS="$TEST_ROOT/events"
+mkdir -p "$ELFSHAKER_DATA/packs/loose"
+printf 'old failure\n' > "$ELFSHAKER_DATA/packs/loose/$SNAPSHOT_NAME.pack.idx"
+
+RUN="$TEST_ROOT/run"
+mkdir -p "$RUN"
+(
+    cd "$RUN"
+    PATH="$BIN:$SCRIPT_DIR:$PATH" \
+    GIT_DIR="$REPOSITORY/.git" \
+    ELFSHAKER_DATA="$ELFSHAKER_DATA" \
+    ELFSHAKER_TEST_EVENTS="$EVENTS" \
+    MANYCLANGS_COMMIT_LIST_FILE="$COMMIT_LIST" \
+    MANYCLANGS_REBUILD_EXISTING=1 \
+    MANYCLANGS_PACK_NAME=aarch64-ubuntu2004-manyclangs-202605-libc-repair1 \
+    MANYCLANGS_NPARALLEL=1 \
+    MANYCLANGS_NODELETE=1 \
+    "$SCRIPT" 2026 05 </dev/null
+)
+
+grep -Fx "store $SNAPSHOT_NAME" "$EVENTS" >/dev/null ||
+    fail "existing snapshot was not rebuilt"
+grep -Fx "pack aarch64-ubuntu2004-manyclangs-202605-libc-repair1" "$EVENTS" >/dev/null ||
+    fail "requested pack name was not used"
+test -f "$RUN/mc-build-202605-part00/libc/sentinel" ||
+    fail "libc was not restored"
+
+SKIP_EVENTS="$TEST_ROOT/skip-events"
+SKIP_RUN="$TEST_ROOT/skip-run"
+mkdir -p "$SKIP_RUN"
+(
+    cd "$SKIP_RUN"
+    PATH="$BIN:$SCRIPT_DIR:$PATH" \
+    GIT_DIR="$REPOSITORY/.git" \
+    ELFSHAKER_DATA="$ELFSHAKER_DATA" \
+    ELFSHAKER_TEST_EVENTS="$SKIP_EVENTS" \
+    MANYCLANGS_COMMIT_LIST_FILE="$COMMIT_LIST" \
+    MANYCLANGS_PACK_NAME=aarch64-ubuntu2004-manyclangs-202605-skip-test \
+    MANYCLANGS_NPARALLEL=1 \
+    MANYCLANGS_NODELETE=1 \
+    "$SCRIPT" 2026 05 </dev/null
+)
+if grep -q '^store ' "$SKIP_EVENTS"
+then
+    fail "existing snapshot was rebuilt without MANYCLANGS_REBUILD_EXISTING"
+fi
+
+SELECTION_ARGS="$TEST_ROOT/selection-args"
+git-list-between() {
+    printf '%s\n' "$*" > "$SELECTION_ARGS"
+    printf '%s %s\n' "$COMMIT_SHA" "$SNAPSHOT_NAME"
+}
+export -f git-list-between
+# shellcheck source=contrib/manyclangs-build-month
+source "$SCRIPT"
+commits_for_month 2026 05 >/dev/null
+grep -qw libc "$SELECTION_ARGS" ||
+    fail "libc was not included in monthly commit selection"
+
+BAD_LIST="$TEST_ROOT/bad-list.txt"
+printf '%s %s extra\n' "$COMMIT_SHA" "$SNAPSHOT_NAME" > "$BAD_LIST"
+if validate_commit_list "$BAD_LIST" 2026 05
+then
+    fail "malformed commit list was accepted"
+fi
+if validate_pack_name ..
+then
+    fail "unsafe pack name was accepted"
+fi
+
+echo "test-manyclangs-build-month: ok"

--- a/test-scripts/check.sh
+++ b/test-scripts/check.sh
@@ -47,9 +47,13 @@ trap_exit() {
 }
 
 all_pwd_sha1sums() {
-  find . \( -name elfshaker_data -prune \) -o -type f -printf '%P\n' | \
-    xargs sha1sum | \
-    awk '{print $1" "$2}' | sort -k2,2
+  local path checksum
+  while IFS= read -r -d '' path; do
+    checksum=$(sha1sum < "$path")
+    printf '%s %s\n' "${checksum%% *}" "$path"
+  done < <(
+    find . \( -name elfshaker_data -prune \) -o -type f -printf '%P\0'
+  ) | sort -k2,2
 }
 
 elfshaker_sha1sums() {
@@ -126,6 +130,10 @@ serve_file_http() {
 }
 
 # TESTS
+
+test_empty_worktree_sha1sums() {
+  [[ -z "$(all_pwd_sha1sums)" ]]
+}
 
 test_list_works() {
   before_test
@@ -911,6 +919,7 @@ main() {
 
   SKIP_BAD_WINDOWS_TESTS="${SKIP_BAD_WINDOWS_TESTS-}" # default empty; set to non-empty to skip failing tests on window.
 
+  run_test test_empty_worktree_sha1sums
   run_test test_list_works
   run_test test_extract_reset_on_empty_works
   run_test test_extract_again_works


### PR DESCRIPTION
LLVM recently added libc to the set of required directories to build llvm/clang, so make sure we also check out that one.

Also add a repair mechanism to allow us to build the missing parts.
