### PR TITLE
Fix concurrent loose object publication

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -6,10 +6,10 @@ jobs:
   clippy_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - run: cargo fmt --all -- --check
       - run: rustup component add clippy
-      - uses: actions-rs/clippy-check@v1
+      - uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d # v1.0.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         target: [aarch64-pc-windows-msvc, x86_64-unknown-linux-musl, aarch64-unknown-linux-musl, aarch64-apple-darwin, x86_64-apple-darwin]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - name: Compile and release
-        uses: rust-build/rust-build.action@latest
+        uses: rust-build/rust-build.action@6febf1b0ed6499a46610b58ef9d810398e75f3c2 # v1.4.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUSTTARGET: ${{ matrix.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
     - name: Build
       run: cargo build --release --verbose
     - name: Run tests

--- a/.github/workflows/test-nix.yml
+++ b/.github/workflows/test-nix.yml
@@ -9,43 +9,40 @@ on:
 jobs:
   build-linux:
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
-      - uses: nixbuild/nix-quick-install-action@master
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: nixbuild/nix-quick-install-action@v34
       - uses: nix-community/cache-nix-action@main
         with:
           primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
-      - uses: docker/setup-qemu-action@v2
-      - name: Build
-        run: nix build --log-lines 1000 .#release
-      - name: ls
-        run: ls -la result/
-
-  build-macos-x86_64:
-    runs-on: macos-13 # 13 runner is x86.
-    steps:
-      - uses: actions/checkout@v3
-      - uses: nixbuild/nix-quick-install-action@master
-      - uses: nix-community/cache-nix-action@main
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
         with:
-          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
-      - name: Build
-        run: nix build --log-lines 1000 .#release
+          image: docker.io/tonistiigi/binfmt@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3
+          platforms: arm64
+      - name: Build aarch64 musl
+        run: timeout --signal=TERM --kill-after=30s 25m nix build -L --max-jobs 1 --cores 2 --no-link .#elfshaker-aarch64-musl
+      - name: Build x86_64 musl
+        run: timeout --signal=TERM --kill-after=30s 25m nix build -L --max-jobs 1 --cores 2 --no-link .#elfshaker-x86_64-musl
+      - name: Build x86_64 Windows
+        run: timeout --signal=TERM --kill-after=30s 25m nix build -L --max-jobs 1 --cores 2 --no-link .#elfshaker-x86_64-windows
+      - name: Build release archive
+        run: timeout --signal=TERM --kill-after=30s 5m nix build -L --max-jobs 1 --cores 2 .#release
       - name: ls
         run: ls -la result/
 
   build-macos-arm64:
     runs-on: macos-14 # 14 runner is aarch64.
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
-      - uses: nixbuild/nix-quick-install-action@master
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: nixbuild/nix-quick-install-action@v34
       - uses: nix-community/cache-nix-action@main
         with:
           primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
       - name: Build
-        run: nix build --log-lines 1000 .#release
+        run: nix build -L .#release
       - name: ls
         run: ls -la result/

--- a/.github/workflows/test-nix.yml
+++ b/.github/workflows/test-nix.yml
@@ -12,8 +12,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
-      - uses: nixbuild/nix-quick-install-action@v34
-      - uses: nix-community/cache-nix-action@main
+      - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
+      - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
         with:
           primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
@@ -37,8 +37,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
-      - uses: nixbuild/nix-quick-install-action@v34
-      - uses: nix-community/cache-nix-action@main
+      - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
+      - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
         with:
           primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}

--- a/elfshaker.nix
+++ b/elfshaker.nix
@@ -69,7 +69,9 @@ naerskBuildPackage isWindows target {
       ${buildPackages.tree}/bin/tree $out
       echo "Testing elfshaker binary with check.sh"
       export ELFSHAKER_BIN=$out/bin/elfshaker
-      ${maybeWindows} "$SHELL" ${./.}/test-scripts/check.sh ${elfshakerBinRunner} ${./.}/test-scripts/artifacts/${packName}
+      ${maybeWindows} ${buildPackages.coreutils}/bin/timeout \
+        --signal=TERM --kill-after=30s 10m \
+        "$SHELL" ${./.}/test-scripts/check.sh ${elfshakerBinRunner} ${./.}/test-scripts/artifacts/${packName}
     '';
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -32,24 +32,26 @@
     packages = forAllSystems (system: let
       pkgs = import nixpkgs { inherit system; };
 
-      rustToolchain = with fenix.packages.${system};
-        combine [
-          stable.cargo
-          stable.clippy
-          rust-analyzer
-          stable.rust-src
-          stable.rustc
-          stable.rustfmt
-          targets.aarch64-unknown-linux-gnu.stable.rust-std
-          targets.aarch64-unknown-linux-musl.stable.rust-std
-          targets.aarch64-unknown-linux-musl.stable.rust-std
-          targets.x86_64-unknown-linux-musl.stable.rust-std
-          targets.x86_64-pc-windows-gnu.stable.rust-std
-        ];
+      fenixPackages = fenix.packages.${system};
+      rustBuildComponents = with fenixPackages; [
+        stable.cargo
+        stable.rustc
+        targets.aarch64-unknown-linux-gnu.stable.rust-std
+        targets.aarch64-unknown-linux-musl.stable.rust-std
+        targets.x86_64-unknown-linux-musl.stable.rust-std
+        targets.x86_64-pc-windows-gnu.stable.rust-std
+      ];
+      rustBuildToolchain = fenixPackages.combine rustBuildComponents;
+      rustToolchain = fenixPackages.combine (rustBuildComponents ++ (with fenixPackages; [
+        stable.clippy
+        rust-analyzer
+        stable.rust-src
+        stable.rustfmt
+      ]));
 
       naersk' = naersk.lib.${system}.override {
-        cargo = rustToolchain;
-        rustc = rustToolchain;
+        cargo = rustBuildToolchain;
+        rustc = rustBuildToolchain;
       };
 
       naerskBuildPackage = isWindows: target: args:

--- a/src/bin/elfshaker/gc.rs
+++ b/src/bin/elfshaker/gc.rs
@@ -31,6 +31,9 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
     }
 
     let repo = open_repo_from_cwd(data_dir)?;
+    if !dry_run {
+        repo.lock_exclusive()?;
+    }
     let mut remaining_roots = repo.loose_packs()?;
 
     let mut freed_bytes = 0;

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -38,6 +38,33 @@ pub fn ensure_dir(path: &Path) -> io::Result<()> {
 ///
 /// NOTE: [`temp_dir`] and [`dest`] must be on the same filesystem!
 pub fn write_file_atomic(mut r: impl Read, temp_dir: &Path, dest: &Path) -> io::Result<()> {
+    let (temp_path, _temp_file) = prepare_atomic_write(&mut r, temp_dir)?;
+    fs::rename(temp_path, dest)
+}
+
+/// Atomically writes a file, or succeeds if another writer publishes the destination first.
+pub fn write_file_atomic_or_existing(
+    mut r: impl Read,
+    temp_dir: &Path,
+    dest: &Path,
+) -> io::Result<()> {
+    if dest.is_file() {
+        return Ok(());
+    }
+
+    let (temp_path, temp_file) = prepare_atomic_write(&mut r, temp_dir)?;
+    match fs::rename(&temp_path, dest) {
+        Ok(()) => Ok(()),
+        Err(_) if dest.is_file() => {
+            drop(temp_file);
+            let _ = fs::remove_file(temp_path);
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn prepare_atomic_write(mut r: impl Read, temp_dir: &Path) -> io::Result<(PathBuf, File)> {
     let temp_path = create_temp_path(temp_dir);
     let mut temp_file = create_file(&temp_path, None)?;
     // The presence of a lock on the file indicates that this tempfile is in
@@ -46,7 +73,7 @@ pub fn write_file_atomic(mut r: impl Read, temp_dir: &Path, dest: &Path) -> io::
     temp_file.try_lock_exclusive()?;
     io::copy(&mut r, &mut temp_file)?;
     temp_file.sync_data()?;
-    fs::rename(temp_path, dest)
+    Ok((temp_path, temp_file))
 }
 
 /// Returns a unique path suitable for a temporary file.

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -270,11 +270,11 @@ impl EmptyDirectoryCleanupQueue {
             Some(x) => x,
         };
 
-        if *last_boundary == boundary_dir.as_ref() && last_leaf.starts_with(&leaf_dir) {
-            // When scheduling a directory that is a subdirectory of the
-            // last seen directory, we can simply overwrite the
-            // value. remove_empty_dirs will consider the previous
-            // directory for deletion when it recurses up the hierarchy.
+        if *last_boundary == boundary_dir.as_ref() && leaf_dir.as_ref().starts_with(&*last_leaf) {
+            // When scheduling a directory that is a subdirectory of the last
+            // seen directory, we can simply overwrite the value.
+            // remove_empty_dirs will consider the previous directory for
+            // deletion when it recurses up the hierarchy.
             *last_leaf = leaf_dir.into();
             Ok(())
         } else {
@@ -469,6 +469,33 @@ mod tests {
             "The directory should have been emptied!"
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_cleanup_queue_processes_leaf_before_ancestor() -> io::Result<()> {
+        let temp_dir = TempDir::new("test_cleanup_queue_processes_leaf_before_ancestor")?;
+        let boundary_dir = temp_dir.0.join("test_root");
+        let parent_dir = boundary_dir.join("1");
+        let leaf_dir = parent_dir.join("41");
+        let leaf_file = leaf_dir.join("1c");
+        let sibling_file = parent_dir.join("43");
+
+        fs::create_dir_all(&leaf_dir)?;
+        fs::write(&leaf_file, [])?;
+        fs::write(&sibling_file, [])?;
+
+        let mut q = EmptyDirectoryCleanupQueue::new();
+        fs::remove_file(&leaf_file)?;
+        q.enqueue(&leaf_dir, &boundary_dir)?;
+        fs::remove_file(&sibling_file)?;
+        q.enqueue(&parent_dir, &boundary_dir)?;
+        q.process()?;
+
+        assert!(
+            !leaf_dir.exists(),
+            "the abandoned leaf directory should be removed"
+        );
         Ok(())
     }
 }

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -230,7 +230,11 @@ impl Repository {
         })
     }
 
-    fn lock_exclusive(&self) -> io::Result<()> {
+    /// Acquires an exclusive lock for the remaining lifetime of this repository.
+    ///
+    /// Multi-step mutations must acquire this lock before reading any repository
+    /// state used to decide what to modify.
+    pub fn lock_exclusive(&self) -> io::Result<()> {
         let mut is_locked_exclusively = self
             .is_locked_exclusively
             .lock()

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -25,7 +25,7 @@ use super::constants::REPO_DIR;
 use super::error::Error;
 use super::fs::{
     create_file, create_temp_path, ensure_dir, get_last_modified, open_file, write_file_atomic,
-    EmptyDirectoryCleanupQueue, FileMode, MetadataFileModeExt,
+    write_file_atomic_or_existing, EmptyDirectoryCleanupQueue, FileMode, MetadataFileModeExt,
 };
 use super::pack::{write_skippable_frame, Pack, PackFrame, PackHeader, PackId, SnapshotId};
 use super::remote;
@@ -1289,16 +1289,8 @@ impl Repository {
         checksum: &ObjectChecksum,
     ) -> io::Result<()> {
         let obj_path = self.loose_object_path(checksum);
-        if obj_path.exists() {
-            // No need to do anything. Object writes are atomic, so if an object
-            // with the same checksum already exists, there is no need to do anything.
-            return Ok(());
-        }
-
-        // Write to disk
         fs::create_dir_all(obj_path.parent().unwrap())?;
-        write_file_atomic(&mut reader, temp_dir, &obj_path)?;
-        Ok(())
+        write_file_atomic_or_existing(&mut reader, temp_dir, &obj_path)
     }
 
     pub fn loose_object_checksum(&self, path: &Path) -> Result<ObjectChecksum, Error> {
@@ -1491,6 +1483,76 @@ mod tests {
                 .join("deadbeefbadc0de0faf0deadbeefbadc0de0"),
             path,
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn loose_object_write_accepts_competing_writer() -> io::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        struct CompetingReader {
+            contents: &'static [u8],
+            destination: PathBuf,
+            destination_dir: PathBuf,
+            offset: usize,
+        }
+
+        impl Read for CompetingReader {
+            fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+                if self.offset == 0 {
+                    fs::write(&self.destination, self.contents)?;
+                    fs::set_permissions(&self.destination_dir, fs::Permissions::from_mode(0o555))?;
+                }
+
+                let remaining = &self.contents[self.offset..];
+                let len = remaining.len().min(buf.len());
+                buf[..len].copy_from_slice(&remaining[..len]);
+                self.offset += len;
+                Ok(len)
+            }
+        }
+
+        struct Cleanup(PathBuf);
+
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = fs::remove_dir_all(&self.0);
+            }
+        }
+
+        let root = create_temp_path(&std::env::temp_dir());
+        fs::create_dir(&root)?;
+        let _cleanup = Cleanup(root.clone());
+        let data_dir = root.join(REPO_DIR);
+        let temp_dir = data_dir.join(TEMP_DIR);
+        fs::create_dir_all(&temp_dir)?;
+
+        let repo = Repository {
+            path: root,
+            data_dir,
+            progress_reporter_factory: Box::new(|_| ProgressReporter::dummy()),
+            lock_file: None,
+            is_locked_exclusively: AtomicBool::new(false),
+        };
+
+        let checksum: [u8; 20] = Sha1::digest(b"same contents").into();
+        let destination = repo.loose_object_path(&checksum);
+        let destination_dir = destination.parent().unwrap().to_path_buf();
+        fs::create_dir_all(&destination_dir)?;
+
+        let mut reader = CompetingReader {
+            contents: b"same contents",
+            destination: destination.clone(),
+            destination_dir: destination_dir.clone(),
+            offset: 0,
+        };
+        let result = repo.write_loose_object(&mut reader, &temp_dir, &checksum);
+
+        fs::set_permissions(&destination_dir, fs::Permissions::from_mode(0o755))?;
+        result?;
+        assert_eq!(b"same contents", fs::read(destination)?.as_slice());
+        assert!(temp_dir.read_dir()?.next().is_none());
+        Ok(())
     }
 
     #[test]

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -9,10 +9,7 @@ use std::{
     io::{self, Read, Write},
     path::{Path, PathBuf},
     str::FromStr,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc, Mutex,
-    },
+    sync::{Arc, Mutex},
     time::SystemTime,
 };
 
@@ -144,7 +141,7 @@ pub struct Repository {
     /// when the repository instance is created/destroyed.
     /// None represents read-only repository.
     lock_file: Option<fs::File>,
-    is_locked_exclusively: AtomicBool,
+    is_locked_exclusively: Mutex<bool>,
 }
 
 impl Repository {
@@ -190,7 +187,7 @@ impl Repository {
                 if let Err(e) = fs2::FileExt::try_lock_shared(&lock_file) {
                     if e.raw_os_error() == fs2::lock_contended_error().raw_os_error() {
                         warn!("Blocking until the repository mutex is unlocked...");
-                        lock_file.lock_exclusive()?;
+                        FileExt::lock_shared(&lock_file)?;
                     } else {
                         return Err(e.into());
                     }
@@ -209,27 +206,36 @@ impl Repository {
             data_dir,
             progress_reporter_factory: Box::new(|_| ProgressReporter::dummy()),
             lock_file,
-            is_locked_exclusively: AtomicBool::new(false),
+            is_locked_exclusively: Mutex::new(false),
         })
     }
 
     fn lock_exclusive(&self) -> io::Result<()> {
-        if self.is_locked_exclusively.load(Ordering::Acquire) {
+        let mut is_locked_exclusively = self
+            .is_locked_exclusively
+            .lock()
+            .map_err(|_| io::Error::other("repository lock state poisoned"))?;
+        if *is_locked_exclusively {
             return Ok(());
         }
-        if let Some(lock_file) = &self.lock_file {
-            if let Err(e) = lock_file.try_lock_exclusive() {
-                if e.raw_os_error() == fs2::lock_contended_error().raw_os_error() {
-                    warn!("Blocking until the repository mutex is unlocked...");
-                    lock_file.lock_exclusive()?;
-                } else {
-                    return Err(e);
-                }
-            }
-        } else {
+        let Some(lock_file) = &self.lock_file else {
             error!("Modifying readonly repository is not allowed.");
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "modifying readonly repository is not allowed",
+            ));
+        };
+
+        FileExt::unlock(lock_file)?;
+        if let Err(e) = FileExt::try_lock_exclusive(lock_file) {
+            if e.raw_os_error() == fs2::lock_contended_error().raw_os_error() {
+                warn!("Blocking until the repository mutex is unlocked...");
+                FileExt::lock_exclusive(lock_file)?;
+            } else {
+                return Err(e);
+            }
         }
-        self.is_locked_exclusively.store(true, Ordering::Release);
+        *is_locked_exclusively = true;
         Ok(())
     }
 
@@ -1460,6 +1466,30 @@ mod tests {
     };
 
     #[test]
+    fn repository_lock_upgrades_to_exclusive() -> Result<(), Error> {
+        let root = create_temp_path(&std::env::temp_dir());
+        let data_dir = root.join(REPO_DIR);
+        fs::create_dir_all(&data_dir)?;
+
+        let repo = Repository::open_with_data_dir(&root, &data_dir)?;
+        repo.lock_exclusive()?;
+
+        let competing_lock = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(data_dir.join("mutex"))?;
+        let error = FileExt::try_lock_shared(&competing_lock).unwrap_err();
+        assert_eq!(
+            error.raw_os_error(),
+            fs2::lock_contended_error().raw_os_error()
+        );
+
+        drop(repo);
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
+
+    #[test]
     fn building_loose_object_paths_works() {
         let checksum = [
             0xFA, 0xF0, 0xDE, 0xAD, 0xBE, 0xEF, 0xBA, 0xDC, 0x0D, 0xE0, 0xFA, 0xF0, 0xDE, 0xAD,
@@ -1471,7 +1501,7 @@ mod tests {
             data_dir: "/repo/elfshaker_data".into(),
             progress_reporter_factory: Box::new(|_| ProgressReporter::dummy()),
             lock_file: Some(fs::File::create(&test_lock).unwrap()),
-            is_locked_exclusively: AtomicBool::new(false),
+            is_locked_exclusively: Mutex::new(false),
         };
         fs::remove_file(&test_lock).unwrap();
         let path = repo.loose_object_path(&checksum);
@@ -1532,7 +1562,7 @@ mod tests {
             data_dir,
             progress_reporter_factory: Box::new(|_| ProgressReporter::dummy()),
             lock_file: None,
-            is_locked_exclusively: AtomicBool::new(false),
+            is_locked_exclusively: Mutex::new(false),
         };
 
         let checksum: [u8; 20] = Sha1::digest(b"same contents").into();

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -144,6 +144,26 @@ pub struct Repository {
     is_locked_exclusively: Mutex<bool>,
 }
 
+fn restore_shared_lock_on_error(
+    lock_file: &fs::File,
+    lock_result: io::Result<()>,
+) -> io::Result<()> {
+    let Err(lock_error) = lock_result else {
+        return Ok(());
+    };
+
+    FileExt::lock_shared(lock_file).map_err(|restore_error| {
+        io::Error::new(
+            restore_error.kind(),
+            format!(
+                "failed to acquire exclusive repository lock ({lock_error}); \
+                 failed to restore shared repository lock ({restore_error})"
+            ),
+        )
+    })?;
+    Err(lock_error)
+}
+
 impl Repository {
     /// Opens the specified repository.
     ///
@@ -227,14 +247,17 @@ impl Repository {
         };
 
         FileExt::unlock(lock_file)?;
-        if let Err(e) = FileExt::try_lock_exclusive(lock_file) {
+        let lock_result = if let Err(e) = FileExt::try_lock_exclusive(lock_file) {
             if e.raw_os_error() == fs2::lock_contended_error().raw_os_error() {
                 warn!("Blocking until the repository mutex is unlocked...");
-                FileExt::lock_exclusive(lock_file)?;
+                FileExt::lock_exclusive(lock_file)
             } else {
-                return Err(e);
+                Err(e)
             }
-        }
+        } else {
+            Ok(())
+        };
+        restore_shared_lock_on_error(lock_file, lock_result)?;
         *is_locked_exclusively = true;
         Ok(())
     }
@@ -1479,6 +1502,38 @@ mod tests {
             .write(true)
             .open(data_dir.join("mutex"))?;
         let error = FileExt::try_lock_shared(&competing_lock).unwrap_err();
+        assert_eq!(
+            error.raw_os_error(),
+            fs2::lock_contended_error().raw_os_error()
+        );
+
+        drop(repo);
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn failed_repository_lock_upgrade_restores_shared_lock() -> Result<(), Error> {
+        let root = create_temp_path(&std::env::temp_dir());
+        let data_dir = root.join(REPO_DIR);
+        fs::create_dir_all(&data_dir)?;
+
+        let repo = Repository::open_with_data_dir(&root, &data_dir)?;
+        let lock_file = repo.lock_file.as_ref().unwrap();
+        FileExt::unlock(lock_file)?;
+
+        let error = restore_shared_lock_on_error(
+            lock_file,
+            Err(io::Error::other("injected exclusive lock failure")),
+        )
+        .unwrap_err();
+        assert_eq!(error.to_string(), "injected exclusive lock failure");
+
+        let competing_lock = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(data_dir.join("mutex"))?;
+        let error = FileExt::try_lock_exclusive(&competing_lock).unwrap_err();
         assert_eq!(
             error.raw_os_error(),
             fs2::lock_contended_error().raw_os_error()

--- a/test-scripts/check.sh
+++ b/test-scripts/check.sh
@@ -35,9 +35,12 @@ cleanup() {
 trap_exit() {
   exit_code=$?
   if [[ $exit_code != 0 ]]; then
-    echo "Script exited with error, tempfiles preserved in $temp_dir"
-    read -n 1 -s -r -p "Press any key to continue with cleanup."
-    echo
+    echo "Script exited with error"
+    if [[ -t 0 ]]; then
+      echo "Tempfiles preserved in $temp_dir until cleanup is confirmed"
+      read -n 1 -s -r -p "Press any key to continue with cleanup."
+      echo
+    fi
   fi
   cleanup
   exit $exit_code

--- a/test-scripts/check.sh
+++ b/test-scripts/check.sh
@@ -753,20 +753,22 @@ test_gc_snapshots_dry_run() {
 
 test_gc_objects() {
   # Create loose snapshot with two objects
-  touch foo bar
+  printf '%s' foo > foo
+  printf '%s' bar > bar
   "$elfshaker" store two_objects
   two_objects_pack_path="./elfshaker_data/packs/loose/two_objects.pack.idx"
 
-    # Create loose snapshot with two *more* objects
-  touch baz blar
+  # Create loose snapshot with two *more* objects
+  printf '%s' baz > baz
+  printf '%s' blar > blar
   "$elfshaker" store four_objects
   four_objects_pack_path="./elfshaker_data/packs/loose/four_objects.pack.idx"
 
   # Delete the second loose snapshot
-  rm $four_objects_pack_path
+  rm "$four_objects_pack_path"
 
   objects_before_gc=$(find elfshaker_data/loose -type f | wc -l)
-  if [ objects_before_gc -ne 4 ]; then
+  if [ "$objects_before_gc" -ne 4 ]; then
     echo 'Expected 4 loose objects'
     exit 1
   fi
@@ -774,8 +776,21 @@ test_gc_objects() {
   "$elfshaker" gc -o --verbose
 
   objects_after_gc=$(find elfshaker_data/loose -type f | wc -l)
-  if [ objects_after_gc -ne 2 ]; then
+  if [ "$objects_after_gc" -ne 2 ]; then
     echo 'Expected 2 loose objects after GC'
+    exit 1
+  fi
+}
+
+test_store_duplicate_content_works() {
+  printf '%s' duplicate > foo
+  cp foo bar
+
+  "$elfshaker" store duplicate_objects
+
+  object_count=$(find elfshaker_data/loose -type f | wc -l)
+  if [ "$object_count" -ne 1 ]; then
+    echo 'Expected duplicate files to share one loose object'
     exit 1
   fi
 }
@@ -814,15 +829,16 @@ test_explode_zero_length_creates_parents() {
 
 test_gc_objects_dry_run() {
   # Create loose snapshot with two objects
-  touch foo bar
+  printf '%s' foo > foo
+  printf '%s' bar > bar
   "$elfshaker" store two_objects
   two_objects_pack_path="./elfshaker_data/packs/loose/two_objects.pack.idx"
 
   # Delete the loose snapshot
-  rm $two_objects_pack_path
+  rm "$two_objects_pack_path"
 
   objects_before_gc=$(find elfshaker_data/loose -type f | wc -l)
-  if [ objects_before_gc -ne 2 ]; then
+  if [ "$objects_before_gc" -ne 2 ]; then
     echo 'Expected 2 loose objects'
     exit 1
   fi
@@ -830,7 +846,7 @@ test_gc_objects_dry_run() {
   "$elfshaker" gc -o --dry-run --verbose
 
   objects_after_gc=$(find elfshaker_data/loose -type f | wc -l)
-  if [ objects_after_gc -ne 2 ]; then
+  if [ "$objects_after_gc" -ne 2 ]; then
     echo 'Expected 2 loose objects after GC'
     exit 1
   fi
@@ -908,10 +924,9 @@ main() {
   run_test test_clone_fetches_indexes
   [ -z "$SKIP_BAD_WINDOWS_TESTS" ] && run_test test_gc_snapshots
   [ -z "$SKIP_BAD_WINDOWS_TESTS" ] && run_test test_gc_snapshots_dry_run
+  run_test test_store_duplicate_content_works
   run_test test_gc_objects
-  # Skipped because "*FATAL*: Access denied. (os error 5) (PermissionDenied)"
-  # observed in CI on windows.
-  [ -z "$SKIP_BAD_WINDOWS_TESTS" ] && run_test test_gc_objects_dry_run
+  run_test test_gc_objects_dry_run
   run_test test_read_only
   run_test test_explode_zero_length_creates_parents
 }

--- a/test-scripts/check.sh
+++ b/test-scripts/check.sh
@@ -193,6 +193,21 @@ test_extract_filetype_change_works_with_contents() {
   "$elfshaker" --verbose extract s0
 }
 
+test_extract_directory_to_file_with_removed_sibling_works() {
+  mkdir 1
+  echo target > 1/41
+  "$elfshaker" --verbose store s0
+
+  rm 1/41
+  mkdir 1/41
+  echo child > 1/41/1c
+  echo sibling > 1/43
+  "$elfshaker" --verbose store s1
+
+  "$elfshaker" --verbose extract s0
+  verify_snapshot loose/s0:s0
+}
+
 test_extract_file_modes_preserved() {
   umask 0002
   touch foobar
@@ -899,6 +914,7 @@ main() {
   run_test test_extract_different_works
   [ -z "$SKIP_BAD_WINDOWS_TESTS" ] && run_test test_extract_filetype_change_works
   [ -z "$SKIP_BAD_WINDOWS_TESTS" ] && run_test test_extract_filetype_change_works_with_contents
+  [ -z "$SKIP_BAD_WINDOWS_TESTS" ] && run_test test_extract_directory_to_file_with_removed_sibling_works
   [ -z "$SKIP_BAD_WINDOWS_TESTS" ] && run_test test_extract_file_modes_preserved
   [ -z "$SKIP_BAD_WINDOWS_TESTS" ] && run_test test_extract_zero_length_noreadperm_works
   [ -z "$SKIP_BAD_WINDOWS_TESTS" ] && test_extract_multiple_file_removal_same_dir


### PR DESCRIPTION
Snapshot creation hashes input files in parallel, so files with identical
content can race to publish the same checksum path. Windows rejects the
losing rename with AccessDenied even though the required object now exists.

Separate temporary-file preparation from publication and accept a failed
loose-object rename when another writer has published the destination. Add
regression coverage for the race and repair the object GC test fixtures and
assertions.
