### PR TITLE
Prepare release validation and CI workflows

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -2,6 +2,9 @@ on: [push, pull_request]
 
 name: Clippy check
 
+permissions:
+  contents: read
+
 jobs:
   clippy_check:
     runs-on: ubuntu-latest
@@ -9,7 +12,4 @@ jobs:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - run: cargo fmt --all -- --check
       - run: rustup component add clippy
-      - uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d # v1.0.7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+      - run: cargo clippy --all-features -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-15-intel, macos-15]
+        os: [ubuntu-22.04, macos-15]
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,19 +4,29 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write
+
 jobs:
   release:
-    name: release ${{ matrix.target }}
-    runs-on: ubuntu-latest
+    name: release ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        target: [aarch64-pc-windows-msvc, x86_64-unknown-linux-musl, aarch64-unknown-linux-musl, aarch64-apple-darwin, x86_64-apple-darwin]
+        os: [ubuntu-22.04, macos-15-intel, macos-15]
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
-      - name: Compile and release
-        uses: rust-build/rust-build.action@6febf1b0ed6499a46610b58ef9d810398e75f3c2 # v1.4.5
+      - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
+      - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+        with:
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        if: runner.os == 'Linux'
+      - name: Build release artifacts
+        run: nix build --log-lines 1000 .#release
+      - name: Upload release artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUSTTARGET: ${{ matrix.target }}
-          EXTRA_FILES: "README.md LICENSE CONTRIBUTORS"
+        run: gh release upload "${{ github.event.release.tag_name }}" result/* --clobber

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,4 +23,6 @@ jobs:
     - name: Run check
       run: ./test-scripts/check.sh ./target/release/elfshaker ./test-scripts/artifacts/verification.pack
     - name: Generate random pack
-      run: set -x; ./test-scripts/check.sh ./target/release/elfshaker $(contrib/create-test-pack ./target/release/elfshaker 5 64)
+      run: |
+        pack=$(contrib/create-test-pack ./target/release/elfshaker 5 64)
+        ./test-scripts/check.sh ./target/release/elfshaker "$pack"

--- a/.github/workflows/test-nix.yml
+++ b/.github/workflows/test-nix.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     runs-on: ubuntu-22.04
@@ -32,8 +35,23 @@ jobs:
       - name: ls
         run: ls -la result/
 
+  build-macos-x86_64:
+    runs-on: macos-15-intel
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
+      - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+        with:
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
+      - name: Build
+        run: nix build --log-lines 1000 .#release
+      - name: ls
+        run: ls -la result/
+
   build-macos-arm64:
-    runs-on: macos-14 # 14 runner is aarch64.
+    runs-on: macos-15
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3

--- a/.github/workflows/test-nix.yml
+++ b/.github/workflows/test-nix.yml
@@ -35,21 +35,6 @@ jobs:
       - name: ls
         run: ls -la result/
 
-  build-macos-x86_64:
-    runs-on: macos-15-intel
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
-      - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
-      - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
-        with:
-          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
-      - name: Build
-        run: nix build --log-lines 1000 .#release
-      - name: ls
-        run: ls -la result/
-
   build-macos-arm64:
     runs-on: macos-15
     timeout-minutes: 30

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 target/
+
+# Generated local data and binaries from contrib experiments.
+contrib/elfshaker-serve/commits.txt
+contrib/elfshaker-serve/elfshaker-serve
+contrib/elfshaker-serve/snapshots.txt
+contrib/elfshaker-serve/trace.log
+contrib/manyclangs-builder/manyclangs-builder

--- a/contrib/create-test-pack
+++ b/contrib/create-test-pack
@@ -66,7 +66,10 @@ main() {
             (create_rand_file $APPROX_FILE_SIZE)
         done
         # Delete some files.
-        find \( -name elfshaker_data -prune \) -o -type f -print | sort -R | head -n $(rand_int_inclusive 0 $NUM_FILES) | xargs rm -f
+        delete_count="$(rand_int_inclusive 0 "$NUM_FILES")"
+        find \( -name elfshaker_data -prune \) -o -type f -print |
+            shuf -n "$delete_count" |
+            xargs rm -f
         "${ELFSHAKER_BIN}" store "SNAPSHOT-$I" --verbose
     done
 

--- a/docs/contributors/contributing.md
+++ b/docs/contributors/contributing.md
@@ -25,7 +25,8 @@ cargo test
 2. Run the system tests twice: once with the verification pack and once with a fresh pack.
 ```bash
 ./test-scripts/check.sh ./target/release/elfshaker ./test-scripts/artifacts/verification.pack
-./test-scripts/check.sh ./target/release/elfshaker $(contrib/create-test-pack ./target/release/elfshaker 5 64)
+pack=$(contrib/create-test-pack ./target/release/elfshaker 5 64)
+./test-scripts/check.sh ./target/release/elfshaker "$pack"
 ```
 
 **Some tests may fail to run if you are running on a non-standard Linux environment (like if you don't have `/dev/shm`).**

--- a/elfshaker.nix
+++ b/elfshaker.nix
@@ -35,7 +35,7 @@ let
       export WINEPREFIX="/tmp/elfshaker_testing" WINEDEBUG=-all
       export HOME=$WINEPREFIX FONTCONFIG_PATH=${nativePackages.fontconfig.out}/etc/fonts/
       mkdir -p $WINEPREFIX
-      exec ${nativePackages.wine64}/bin/wine64 "''${ELFSHAKER_BIN}.exe" "$@"
+      exec ${nativePackages.wine64}/bin/wine "''${ELFSHAKER_BIN}.exe" "$@"
   # '';
 
   maybeWindows = lib.optionalString isWindows "SKIP_BAD_WINDOWS_TESTS=1";

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1748759782,
-        "narHash": "sha256-MJNhEBsAbxRp/53qsXv6/eaWkGS8zMGX9LuCz1BLeck=",
+        "lastModified": 1777018861,
+        "narHash": "sha256-l+dfxHtTq1jQM53xgYudV8ciECFmJ72PcRAqRS4ys04=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "9be40ad995bac282160ff374a47eed67c74f9c2a",
+        "rev": "7b33c6466f781cd699fe250c5b69dc4193da67a7",
         "type": "github"
       },
       "original": {
@@ -23,16 +23,19 @@
     },
     "naersk": {
       "inputs": {
+        "fenix": [
+          "fenix"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1745925850,
-        "narHash": "sha256-cyAAMal0aPrlb1NgzMxZqeN1mAJ2pJseDhm2m6Um8T0=",
+        "lastModified": 1777031541,
+        "narHash": "sha256-KZ4s1kolHXFQrRGlnB503gDcTrVQMhiczO+LvvwKEPg=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "38bc60bbc157ae266d4a0c96671c6c742ee17a5f",
+        "rev": "5e73301621274c44798bf6c6211ed27fc2ced201",
         "type": "github"
       },
       "original": {
@@ -43,11 +46,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748437600,
-        "narHash": "sha256-hYKMs3ilp09anGO7xzfGs3JqEgUqFMnZ8GMAqI6/k04=",
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7282cb574e0607e65224d33be8241eae7cfe0979",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
         "type": "github"
       },
       "original": {
@@ -67,11 +70,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1748695646,
-        "narHash": "sha256-VwSuuRF4NvAoeHZJRRlX8zAFZ+nZyuiIvmVqBAX0Bcg=",
+        "lastModified": 1776800521,
+        "narHash": "sha256-f8YJfwAOsLFpIoqZuX3yF69UvMLrkx7iVzMH1pJU7cM=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "2a388d1103450d814a84eda98efe89c01b158343",
+        "rev": "8954b66d43225e62c92e8bbcc8500191b5cceb1e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -46,16 +46,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767313136,
-        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "lastModified": 1783389287,
+        "narHash": "sha256-0xIy4dVLqq47rA+mRy0hXDfjhQd4E5PoIns/RmB7nR4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     # version used.
     fenix.url = "github:nix-community/fenix";
     fenix.inputs.nixpkgs.follows = "nixpkgs";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
   };
 
   outputs = { self, nixpkgs, naersk, fenix }: let
@@ -94,7 +94,7 @@
           export HOME=$WINEPREFIX
           export FONTCONFIG_PATH=${pkgs.buildPackages.fontconfig.out}/etc/fonts/
           mkdir -p $WINEPREFIX
-          exec ${pkgs.buildPackages.wine64}/bin/wine64 "$@"
+          exec ${pkgs.buildPackages.wine64}/bin/wine "$@"
         '';
       });
 

--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,25 @@
       args = { inherit naerskBuildPackage rustToolchain; };
       nativePlatform = pkgs.stdenv.buildPlatform;
       nativeArch = nativePlatform.qemuArch; # (the correct spelling)
+      cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+      releaseVersion = "v${cargoToml.package.version}";
+
+      releaseBundle = ''
+        make_archive() {
+          archive="$1"
+          binary="$2"
+          installed_name="$3"
+          root="root-$(basename "$archive" .tar.gz)"
+
+          mkdir -p "$root/elfshaker"
+          cp "$binary" "$root/elfshaker/$installed_name"
+          cp ${./README.md} "$root/elfshaker/README.md"
+          cp ${./LICENSE} "$root/elfshaker/LICENSE"
+          cp ${./CONTRIBUTORS} "$root/elfshaker/CONTRIBUTORS"
+          tar czf "$archive" --directory "$root" elfshaker
+          sha256sum "$archive" > "$archive.sha256sum"
+        }
+      '';
 
 
     in {
@@ -127,23 +146,35 @@
 
       release = pkgs.runCommandNoCC "elfshaker-release" {} (
         if nativePlatform.isLinux then ''
-            tar czf elfshaker-aarch64-musl.tar.gz --directory ${packages.elfshaker-aarch64-musl}/bin elfshaker
-            sha256sum elfshaker-aarch64-musl.tar.gz > elfshaker-aarch64-musl.tar.gz.sha256sum
+            ${releaseBundle}
 
-            tar czf elfshaker-x86_64-musl.tar.gz --directory ${packages.elfshaker-x86_64-musl}/bin elfshaker
-            sha256sum elfshaker-x86_64-musl.tar.gz > elfshaker-x86_64-musl.tar.gz.sha256sum
+            make_archive \
+              elfshaker_${releaseVersion}_aarch64-unknown-linux-musl.tar.gz \
+              ${packages.elfshaker-aarch64-musl}/bin/elfshaker \
+              elfshaker
+
+            make_archive \
+              elfshaker_${releaseVersion}_x86_64-unknown-linux-musl.tar.gz \
+              ${packages.elfshaker-x86_64-musl}/bin/elfshaker \
+              elfshaker
 
             ${lib.optionalString (nativePlatform.isx86) ''
-              tar czf elfshaker-x86_64-windows.tar.gz --directory ${packages.elfshaker-x86_64-windows}/bin elfshaker.exe
-              sha256sum elfshaker-x86_64-windows.tar.gz > elfshaker-x86_64-windows.tar.gz.sha256sum
+              make_archive \
+                elfshaker_${releaseVersion}_x86_64-pc-windows-gnu.tar.gz \
+                ${packages.elfshaker-x86_64-windows}/bin/elfshaker.exe \
+                elfshaker.exe
             ''}
 
             mkdir $out
             cp *.tar.gz* $out
         ''
         else if nativePlatform.isDarwin then ''
-          tar czf elfshaker-${nativePlatform.darwinArch}-darwin${nativePlatform.darwinMinVersion}.tar.gz --directory ${packages.elfshaker}/bin elfshaker
-          sha256sum elfshaker-${nativePlatform.darwinArch}-darwin${nativePlatform.darwinMinVersion}.tar.gz > elfshaker-${nativePlatform.darwinArch}-darwin${nativePlatform.darwinMinVersion}.tar.gz.sha256sum
+          ${releaseBundle}
+
+          make_archive \
+            elfshaker_${releaseVersion}_${nativePlatform.config}.tar.gz \
+            ${packages.elfshaker}/bin/elfshaker \
+            elfshaker
 
           mkdir $out
           cp *.tar.gz* $out

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,7 @@
   inputs = {
     naersk.url = "github:nix-community/naersk";
     naersk.inputs.nixpkgs.follows = "nixpkgs";
+    naersk.inputs.fenix.follows = "fenix";
     # Note: the flake.lock revision of this package determines the rust
     # version used.
     fenix.url = "github:nix-community/fenix";

--- a/src/bin/elfshaker/main.rs
+++ b/src/bin/elfshaker/main.rs
@@ -68,7 +68,7 @@ fn run_subcommand(app: &mut Command, matches: ArgMatches) -> Result<(), Box<dyn 
 fn get_app() -> Command {
     Command::new("elfshaker")
         .override_usage("elfshaker [GLOBAL-OPTS] <SUBCOMMAND> [SUBCOMMAND-OPTS]")
-        // .version(crate_version!())
+        .version(env!("CARGO_PKG_VERSION"))
         .subcommand(extract::get_app())
         .subcommand(store::get_app())
         .subcommand(list::get_app())

--- a/src/packidx.rs
+++ b/src/packidx.rs
@@ -568,7 +568,7 @@ impl PackIndex {
 }
 
 #[cfg(unix)]
-fn os_str_as_bytes(os_str: &OsStr) -> Cow<[u8]> {
+fn os_str_as_bytes(os_str: &OsStr) -> Cow<'_, [u8]> {
     Cow::Borrowed(std::os::unix::ffi::OsStrExt::as_bytes(os_str))
 }
 


### PR DESCRIPTION
Tightens release and validation before larger follow-on work. Updates CI/release workflows, refreshes the Nix release toolchain inputs, reports the CLI package version, makes random pack generation reliable, ignores generated contrib artifacts, and preserves the existing release archive naming/layout while using Nix-built binaries. Tested locally with cargo test and nix build .#release via the Nix MCP; Linux release tarballs were inspected for expected names, checksums, and bundled README/LICENSE/CONTRIBUTORS.