### PR TITLE
nix: make Darwin release portable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,9 @@
         CC_x86_64_pc_windows_gnu = "x86_64-w64-mingw32-gcc";
         CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS = "-L${pkgs.pkgsCross.mingwW64.windows.mingw_w64_pthreads}/lib";
 
+      } // lib.optionalAttrs pkgs.stdenv.isDarwin {
+        CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS = "-C link-arg=-Wl,-dead_strip_dylibs";
+        CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS = "-C link-arg=-Wl,-dead_strip_dylibs";
       } // lib.optionalAttrs isWindows {
         CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER = "x86_64-w64-mingw32-gcc";
         CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER = pkgs.writeShellScript "wine-wrapper" ''
@@ -144,7 +147,9 @@
       elfshaker-aarch64-darwin = pkgs.pkgsCross.aarch64-darwin.callPackage ./elfshaker.nix args;
       elfshaker-x86_64-darwin = pkgs.pkgsCross.x86_64-darwin.callPackage ./elfshaker.nix args;
 
-      release = pkgs.runCommandNoCC "elfshaker-release" {} (
+      release = pkgs.runCommandNoCC "elfshaker-release" {
+        nativeBuildInputs = lib.optionals nativePlatform.isDarwin [ pkgs.darwin.cctools ];
+      } (
         if nativePlatform.isLinux then ''
             ${releaseBundle}
 
@@ -170,6 +175,13 @@
         ''
         else if nativePlatform.isDarwin then ''
           ${releaseBundle}
+
+          otool -L ${packages.elfshaker}/bin/elfshaker > linked-libraries
+          sed '1d' linked-libraries > linked-dependencies
+          if grep -F '${builtins.storeDir}/' linked-dependencies; then
+            echo "Darwin release binary contains Nix runtime dependencies" >&2
+            exit 1
+          fi
 
           make_archive \
             elfshaker_${releaseVersion}_${nativePlatform.config}.tar.gz \


### PR DESCRIPTION
Drop unused dylib load commands during Darwin linking and reject release binaries that retain Nix store runtime dependencies.