### PR TITLE
[codex] protect packs and snapshots from accidental overwrite

### DIFF
--- a/docs/users/usage.md
+++ b/docs/users/usage.md
@@ -49,7 +49,7 @@ A basic workflow in elfshaker is to:
 
 ## Create snapshot
 ```bash
-elfshaker store <snapshot> [--files-from <file>] [--files0-from <file>]
+elfshaker store <snapshot> [--files-from <file>] [--files0-from <file>] [--force]
 ```
 
 ### Example
@@ -59,6 +59,8 @@ elfshaker store my-snapshot
 
 ### Description
 Creates the snapshot `my-snapshot` containing all files in the elfshaker repository.
+By default, an existing snapshot with the same name is preserved and the command fails.
+Pass `--force` to replace it.
 
 *For full command usage, use the `--help` option.*
 ```bash
@@ -99,7 +101,7 @@ elfshaker extract --help
 
 ## Pack loose snapshots
 ```bash
-elfshaker pack <pack> [--frames N]
+elfshaker pack <pack> [--frames N] [--force]
 ```
 
 The set of snapshots to be packed may be supplied with
@@ -112,7 +114,10 @@ elfshaker pack my-pack --frames 8
 ```
 
 ### Description
-Creates the pack `my-pack` (file is `elfshaker_data/packs/my-pack.idx`) by packing all loose snapshots.
+Creates the pack `my-pack` (`elfshaker_data/packs/my-pack.pack` and
+`elfshaker_data/packs/my-pack.pack.idx`) by packing all loose snapshots.
+By default, existing `.pack` or `.pack.idx` files with the same pack name are
+preserved and the command fails. Pass `--force` to replace them.
 
 ### Implementation
 1. Enumerate all loose object files (belonging to loose snapshot) in `elfshaker_data/loose`.

--- a/src/bin/elfshaker/pack.rs
+++ b/src/bin/elfshaker/pack.rs
@@ -2,7 +2,7 @@
 //! Copyright (C) 2021 Arm Limited or its affiliates and Contributors. All rights reserved.
 
 use clap::Command;
-use clap::{Arg, ArgMatches};
+use clap::{Arg, ArgAction, ArgMatches};
 use log::error;
 use log::info;
 use std::{error::Error, fs, io, ops::ControlFlow, str::FromStr};
@@ -126,18 +126,18 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
 
     eprintln!("Compressing objects...");
     // Create a pack using the ordered "loose" index.
-    repo.create_pack(
-        &pack,
-        new_index,
-        &PackOptions {
-            compression_level,
-            // We don't expose the windowLog option yet.
-            compression_window_log: DEFAULT_COMPRESSION_WINDOW_LOG,
-            num_workers: threads,
-            num_frames: frames,
-        },
-        &reporter,
-    )?;
+    let options = PackOptions {
+        compression_level,
+        // We don't expose the windowLog option yet.
+        compression_window_log: DEFAULT_COMPRESSION_WINDOW_LOG,
+        num_workers: threads,
+        num_frames: frames,
+    };
+    if matches.get_flag("force") {
+        repo.create_pack_force(&pack, new_index, &options, &reporter)?;
+    } else {
+        repo.create_pack(&pack, new_index, &options, &reporter)?;
+    }
 
     if let (Some(head), _) = repo.read_head()? {
         if snapshots.iter().any(|pack_id| head.pack() == pack_id) {
@@ -230,6 +230,12 @@ pub(crate) fn get_app() -> Command {
                 .long("snapshots0-from")
                 .value_name("file")
                 .help("Reads the NUL-separated (ASCII \\0) list of snapshots to include in the pack from the specified file. '-' is taken to mean stdin."),
+        )
+        .arg(
+            Arg::new("force")
+                .long("force")
+                .help("Overwrite an existing pack and index with the same name.")
+                .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new("indexes")

--- a/src/bin/elfshaker/store.rs
+++ b/src/bin/elfshaker/store.rs
@@ -1,7 +1,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //! Copyright (C) 2021 Arm Limited or its affiliates and Contributors. All rights reserved.
 
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use log::error;
 use std::{
     error::Error,
@@ -44,7 +44,11 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
     fs::create_dir_all(data_dir)?;
 
     let mut repo = open_repo_from_cwd(data_dir)?;
-    repo.create_snapshot(&snapshot, files.into_iter())?;
+    if matches.get_flag("force") {
+        repo.create_snapshot_force(&snapshot, files.into_iter())?;
+    } else {
+        repo.create_snapshot(&snapshot, files.into_iter())?;
+    }
 
     Ok(())
 }
@@ -73,6 +77,12 @@ pub(crate) fn get_app() -> Command {
                 .long("files0-from")
                 .value_name("file")
                 .help("Reads the NUL-separated (ASCII \\0) list of files to include in the snapshot from the specified file. '-' is taken to mean stdin."),
+        )
+        .arg(
+            Arg::new("force")
+                .long("force")
+                .help("Overwrite an existing snapshot with the same name.")
+                .action(ArgAction::SetTrue),
         )
 }
 

--- a/src/packidx.rs
+++ b/src/packidx.rs
@@ -3,11 +3,9 @@
 
 //! Contains types and function for parsing `.pack.idx` files created by
 //! elfshaker.
+use crate::atomicfile::AtomicCreateFile;
 use crate::entrypool::{EntryPool, Handle};
-use crate::repo::{
-    fs::{create_file, open_file},
-    partition_by_u64,
-};
+use crate::repo::{fs::open_file, partition_by_u64};
 
 use serde::de::{SeqAccess, Visitor};
 use serde::{ser::SerializeTuple, Deserialize, Deserializer, Serialize, Serializer};
@@ -17,7 +15,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::hash::Hash;
-use std::io::{BufReader, BufWriter, Read, Write};
+use std::io::{BufReader, Cursor, Read, Write};
 use std::iter::FromIterator;
 use std::ops::ControlFlow;
 use std::path::Path;
@@ -599,13 +597,17 @@ impl PackIndex {
     }
 
     pub fn save<P: AsRef<Path>>(&self, p: P) -> Result<(), PackError> {
-        // TODO: Use AtomicCreateFile.
-        let wr = create_file(p.as_ref(), None)?;
-        let mut wr = BufWriter::new(wr);
-        Self::write_magic(&mut wr)?;
-
-        rmp_serde::encode::write(&mut wr, self)?;
+        let output = AtomicCreateFile::new(p.as_ref())?;
+        output.commit_content(Cursor::new(self.serialize()?))?;
         Ok(())
+    }
+
+    /// Serializes this index in the on-disk format used by [`PackIndex::save`].
+    pub(crate) fn serialize(&self) -> Result<Vec<u8>, PackError> {
+        let mut bytes = Vec::new();
+        Self::write_magic(&mut bytes)?;
+        rmp_serde::encode::write(&mut bytes, self)?;
+        Ok(bytes)
     }
 
     // Max supported version of the pack index by this version of elfshaker.
@@ -724,5 +726,28 @@ impl Serialize for PackIndex {
                 .collect::<Vec<ObjectMetadata>>(),
         )?;
         s.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn save_does_not_overwrite_existing_index() -> Result<(), Box<dyn std::error::Error>> {
+        let path = crate::repo::fs::create_temp_path(&std::env::temp_dir());
+        fs::write(&path, b"existing index")?;
+
+        let error = PackIndex::new().save(&path).unwrap_err();
+
+        assert!(matches!(
+            error,
+            PackError::IOError(ref error)
+                if error.kind() == std::io::ErrorKind::AlreadyExists
+        ));
+        assert_eq!(fs::read(&path)?, b"existing index");
+        fs::remove_file(path)?;
+        Ok(())
     }
 }

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -6,7 +6,7 @@ use super::{constants::*, fs::set_file_mode, pack::IdError};
 use std::{
     collections::{HashMap, HashSet},
     fs::{self, File},
-    io::{self, Read, Write},
+    io::{self, Cursor, Read, Write},
     path::{Path, PathBuf},
     str::FromStr,
     sync::{Arc, Mutex},
@@ -26,6 +26,7 @@ use super::fs::{
 };
 use super::pack::{write_skippable_frame, Pack, PackFrame, PackHeader, PackId, SnapshotId};
 use super::remote;
+use crate::atomicfile::AtomicCreateFile;
 use crate::progress::ProgressReporter;
 use crate::{
     batch,
@@ -162,6 +163,15 @@ fn restore_shared_lock_on_error(
         )
     })?;
     Err(lock_error)
+}
+
+#[cfg(windows)]
+fn remove_file_if_exists(path: &Path) -> io::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
 }
 
 impl Repository {
@@ -627,8 +637,43 @@ impl Repository {
         I: Iterator<Item = P>,
         P: AsRef<Path>,
     {
+        self.create_snapshot_impl(snapshot, files, false)
+    }
+
+    /// Creates a loose snapshot, replacing an existing snapshot with the same name.
+    pub fn create_snapshot_force<I, P>(
+        &mut self,
+        snapshot: &SnapshotId,
+        files: I,
+    ) -> Result<(), Error>
+    where
+        I: Iterator<Item = P>,
+        P: AsRef<Path>,
+    {
+        self.create_snapshot_impl(snapshot, files, true)
+    }
+
+    fn create_snapshot_impl<I, P>(
+        &mut self,
+        snapshot: &SnapshotId,
+        files: I,
+        force: bool,
+    ) -> Result<(), Error>
+    where
+        I: Iterator<Item = P>,
+        P: AsRef<Path>,
+    {
         let files =
             clean_file_list(self.path.as_ref(), self.data_dir(), files)?.collect::<Vec<_>>();
+        let loose_path = self.data_dir().join(PACKS_DIR).join(LOOSE_DIR);
+        ensure_dir(&loose_path)?;
+        let snapshot_path = loose_path
+            .join(snapshot.tag())
+            .with_extension(PACK_INDEX_EXTENSION);
+        let snapshot_output = (!force)
+            .then(|| AtomicCreateFile::new(&snapshot_path))
+            .transpose()?;
+
         info!("Computing checksums for {} files...", files.len());
 
         let temp_dir = self.temp_dir();
@@ -687,14 +732,14 @@ impl Repository {
         let mut index = PackIndex::new();
         index.push_snapshot(snapshot.tag().to_owned(), pack_entries)?;
 
-        let loose_path = self.data_dir().join(PACKS_DIR).join(LOOSE_DIR);
-        ensure_dir(&loose_path)?;
-
-        index.save(
-            loose_path
-                .join(snapshot.tag())
-                .with_extension(PACK_INDEX_EXTENSION),
-        )?;
+        let index_bytes = index.serialize()?;
+        if let Some(output) = snapshot_output {
+            output.commit_content(Cursor::new(index_bytes))?;
+        } else {
+            #[cfg(windows)]
+            remove_file_if_exists(&snapshot_path)?;
+            write_file_atomic(Cursor::new(index_bytes), &temp_dir, &snapshot_path)?;
+        }
 
         self.update_head(snapshot)?;
 
@@ -715,6 +760,28 @@ impl Repository {
         opts: &PackOptions,
         reporter: &ProgressReporter,
     ) -> Result<(), Error> {
+        self.create_pack_impl(pack, index, opts, reporter, false)
+    }
+
+    /// Creates a pack file, replacing an existing pack and index with the same name.
+    pub fn create_pack_force(
+        &mut self,
+        pack: &PackId,
+        index: PackIndex,
+        opts: &PackOptions,
+        reporter: &ProgressReporter,
+    ) -> Result<(), Error> {
+        self.create_pack_impl(pack, index, opts, reporter, true)
+    }
+
+    fn create_pack_impl(
+        &mut self,
+        pack: &PackId,
+        index: PackIndex,
+        opts: &PackOptions,
+        reporter: &ProgressReporter,
+        force: bool,
+    ) -> Result<(), Error> {
         let PackId::Pack(pack_name) = pack;
 
         // Construct output file path.
@@ -724,6 +791,21 @@ impl Repository {
             pack_path.push(format!("{pack_name}.{PACK_EXTENSION}"));
             pack_path
         };
+        let index_path = pack_path.with_extension(PACK_INDEX_EXTENSION);
+
+        // The index acts as the creation reservation for the pack/index pair.
+        // Check the pack first so a pre-existing pack does not leave behind a
+        // new empty index reservation.
+        if !force && matches!(pack_path.metadata(), Ok(metadata) if metadata.len() > 0) {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("{} already exists and is non-empty", pack_path.display()),
+            )
+            .into());
+        }
+        let index_output = (!force)
+            .then(|| AtomicCreateFile::new(&index_path))
+            .transpose()?;
 
         // Create a temporary file to use during compression.
         let temp_dir = self.temp_dir();
@@ -815,12 +897,28 @@ impl Repository {
         pack_writer.flush()?;
         drop(pack_writer);
 
-        let index_path = pack_path.with_extension(PACK_INDEX_EXTENSION);
         info!("Write index: {}", index_path.display());
-        index.save(index_path)?;
+        let index_bytes = index.serialize()?;
 
-        // Finally, move the .pack file itself to the packs/ dir.
-        fs::rename(&temp_path, &pack_path)?;
+        // Publish the pack before its index so readers never discover an index
+        // whose corresponding pack is still incomplete.
+        if !force {
+            let output = AtomicCreateFile::new(&pack_path)?;
+            output.commit_content(File::open(&temp_path)?)?;
+            fs::remove_file(&temp_path)?;
+        } else {
+            #[cfg(windows)]
+            remove_file_if_exists(&pack_path)?;
+            fs::rename(&temp_path, &pack_path)?;
+        }
+
+        if let Some(output) = index_output {
+            output.commit_content(Cursor::new(index_bytes))?;
+        } else {
+            #[cfg(windows)]
+            remove_file_if_exists(&index_path)?;
+            write_file_atomic(Cursor::new(index_bytes), &temp_dir, &index_path)?;
+        }
 
         Ok(())
     }

--- a/test-scripts/check.sh
+++ b/test-scripts/check.sh
@@ -347,6 +347,23 @@ test_store_twice_works() {
   fi
 }
 
+test_store_existing_requires_force() {
+  echo first > duplicate
+  "$elfshaker" store duplicate-name
+  index=elfshaker_data/packs/loose/duplicate-name.pack.idx
+  checksum_before=$(sha1sum < "$index")
+
+  echo second > duplicate
+  if "$elfshaker" store duplicate-name; then
+    echo "store unexpectedly overwrote an existing snapshot"
+    exit 1
+  fi
+  [[ "$checksum_before" == "$(sha1sum < "$index")" ]]
+
+  "$elfshaker" store --force duplicate-name
+  [[ "$checksum_before" != "$(sha1sum < "$index")" ]]
+}
+
 test_store_finds_new_files() {
   "$elfshaker" --verbose extract --verify --reset "$pack":"$snapshot_b"
   "$elfshaker" --verbose store "$snapshot_b"
@@ -401,6 +418,35 @@ test_pack_simple_works() {
     echo "Checksums do not match!";
     exit 1
   fi
+}
+
+test_pack_existing_requires_force() {
+  echo first > duplicate
+  "$elfshaker" store duplicate-pack-snapshot
+  "$elfshaker" pack duplicate-pack
+  pack_file=elfshaker_data/packs/duplicate-pack.pack
+  index_file=elfshaker_data/packs/duplicate-pack.pack.idx
+  pack_checksum_before=$(sha1sum < "$pack_file")
+  index_checksum_before=$(sha1sum < "$index_file")
+
+  echo second > duplicate
+  "$elfshaker" store duplicate-pack-snapshot-2
+  if "$elfshaker" pack duplicate-pack; then
+    echo "pack unexpectedly overwrote existing output files"
+    exit 1
+  fi
+  [[ "$pack_checksum_before" == "$(sha1sum < "$pack_file")" ]]
+  [[ "$index_checksum_before" == "$(sha1sum < "$index_file")" ]]
+
+  cp "$pack_file" elfshaker_data/packs/orphan.pack
+  if "$elfshaker" pack orphan; then
+    echo "pack unexpectedly accepted a pre-existing pack without an index"
+    exit 1
+  fi
+  [[ ! -e elfshaker_data/packs/orphan.pack.idx ]]
+
+  "$elfshaker" pack --force duplicate-pack
+  [[ "$index_checksum_before" != "$(sha1sum < "$index_file")" ]]
 }
 
 test_pack_two_snapshots_works() {
@@ -933,10 +979,12 @@ main() {
   run_test test_store_works
   run_test test_store_and_extract_different_works
   run_test test_store_twice_works
+  run_test test_store_existing_requires_force
   run_test test_store_finds_new_files
   run_test test_store_empty_directory_works
   run_test test_store_data_dir_works
   run_test test_pack_simple_works
+  run_test test_pack_existing_requires_force
   run_test test_pack_two_snapshots_works
   run_test test_pack_snapshots_from_list_works
   run_test test_pack_multi_snapshots_from_list_works


### PR DESCRIPTION
## Summary

Prevent `store` and `pack` from silently overwriting existing snapshots and pack files.

- use `AtomicCreateFile` to reserve new snapshot indexes before computing file checksums;
- reserve pack creation before starting compression;
- reject existing non-empty `.pack` and `.pack.idx` files by default;
- add `--force` to `store` and `pack` for intentional replacement;
- document the new behavior;
- add unit and system-test coverage for overwrite protection and forced replacement.

## Why

Creating a snapshot or pack with an existing name currently truncates or replaces the existing output. Pack creation can also perform expensive compression work before discovering a conflicting destination.

The new default is fail-safe: existing data is preserved unless the caller explicitly passes `--force`. `AtomicCreateFile` also protects against concurrent creators without relying on a check-then-create sequence.

## Validation

- `cargo test` — 31 tests passed
- `cargo build --release`
- `cargo clippy --all-targets --all-features` — completed with existing warnings in unrelated files
- targeted system tests:
  - `test_store_existing_requires_force`
  - `test_pack_existing_requires_force`
- manual smoke test covering duplicate snapshot rejection, duplicate pack rejection, preserving existing contents, `--force` replacement, and an existing `.pack` without a matching index

The full Linux-oriented system-test script was not run unchanged on macOS because it relies on GNU `realpath`, `find`, `stat`, and `sha1sum` behavior.

Fixes #57
